### PR TITLE
style(frontend): cleanup and formatting pass for property/signup modals and admin properties page

### DIFF
--- a/frontend/src/modals/PropertyUpsertModal.css
+++ b/frontend/src/modals/PropertyUpsertModal.css
@@ -226,7 +226,10 @@
   color: var(--text);
   padding: 10px 12px;
   cursor: pointer;
-  transition: background 180ms ease, color 180ms ease, border-color 180ms ease;
+  transition:
+    background 180ms ease,
+    color 180ms ease,
+    border-color 180ms ease;
 }
 
 .propStatus__btn:hover {
@@ -253,7 +256,10 @@
   color: var(--text);
   padding: 12px 14px;
   cursor: pointer;
-  transition: background 180ms ease, color 180ms ease, border-color 180ms ease;
+  transition:
+    background 180ms ease,
+    color 180ms ease,
+    border-color 180ms ease;
 }
 
 .propBtn:hover {

--- a/frontend/src/modals/PropertyUpsertModal.jsx
+++ b/frontend/src/modals/PropertyUpsertModal.jsx
@@ -106,7 +106,7 @@ export default function PropertyUpsertModal({
       description: initialValue.description ?? "",
     });
   }, [open, initialValue]);
-  
+
   // esc + scroll lock
   useEffect(() => {
     if (!open) return;
@@ -125,7 +125,10 @@ export default function PropertyUpsertModal({
     };
   }, [open, onClose]);
 
-  const titleText = useMemo(() => (isEdit ? "Edit Property" : "Add Property"), [isEdit]);
+  const titleText = useMemo(
+    () => (isEdit ? "Edit Property" : "Add Property"),
+    [isEdit],
+  );
 
   function setField(key, value) {
     setForm((p) => ({ ...p, [key]: value }));
@@ -139,9 +142,13 @@ export default function PropertyUpsertModal({
 
   if (!open) return null;
 
-
   return (
-    <div className="propModalOverlay" onMouseDown={onClose} role="dialog" aria-modal="true">
+    <div
+      className="propModalOverlay"
+      onMouseDown={onClose}
+      role="dialog"
+      aria-modal="true"
+    >
       <div className="propModal" onMouseDown={(e) => e.stopPropagation()}>
         <div className="propModal__header">
           <h2 className="propModal__title">{titleText}</h2>
@@ -190,7 +197,9 @@ export default function PropertyUpsertModal({
               </div>
 
               <div className="propField">
-                <div className="propField__label">Apt, suite, etc (optional)</div>
+                <div className="propField__label">
+                  Apt, suite, etc (optional)
+                </div>
                 <input
                   className="propField__input"
                   value={form.street2}
@@ -461,70 +470,86 @@ export default function PropertyUpsertModal({
           </div>
 
           {/* errors */}
-          {submitError ? <div className="propModal__error">{submitError}</div> : null}
-          {deleteError ? <div className="propModal__error">{deleteError}</div> : null}
+          {submitError ? (
+            <div className="propModal__error">{submitError}</div>
+          ) : null}
+          {deleteError ? (
+            <div className="propModal__error">{deleteError}</div>
+          ) : null}
 
           {/* Actions */}
-        <div className="propActions">
-        {mode === "edit" ? (
-            showDeleteConfirm ? (
-            <div className="propDeleteConfirm">
-                <div className="propDeleteConfirm__text">
-                Delete this property? <span className="propDeleteConfirm__sub">(This cannot be undone)</span>
+          <div className="propActions">
+            {mode === "edit" ? (
+              showDeleteConfirm ? (
+                <div className="propDeleteConfirm">
+                  <div className="propDeleteConfirm__text">
+                    Delete this property?{" "}
+                    <span className="propDeleteConfirm__sub">
+                      (This cannot be undone)
+                    </span>
+                  </div>
+
+                  <div className="propDeleteConfirm__actions">
+                    <button
+                      type="button"
+                      className="propBtn"
+                      disabled={submitting || deleting}
+                      onClick={() => setShowDeleteConfirm(false)}
+                    >
+                      Cancel
+                    </button>
+
+                    <button
+                      type="button"
+                      className="propBtn propBtn--danger"
+                      disabled={submitting || deleting}
+                      onClick={() => onDelete?.()}
+                    >
+                      {deleting ? "Deleting..." : "Yes, Delete"}
+                    </button>
+                  </div>
                 </div>
-
-                <div className="propDeleteConfirm__actions">
-                <button
-                    type="button"
-                    className="propBtn"
-                    disabled={submitting || deleting}
-                    onClick={() => setShowDeleteConfirm(false)}
-                >
-                    Cancel
-                </button>
-
-                <button
+              ) : (
+                <>
+                  <button
                     type="button"
                     className="propBtn propBtn--danger"
                     disabled={submitting || deleting}
-                    onClick={() => onDelete?.()}
-                >
-                    {deleting ? "Deleting..." : "Yes, Delete"}
-                </button>
-                </div>
-            </div>
+                    onClick={() => setShowDeleteConfirm(true)}
+                  >
+                    Delete
+                  </button>
+
+                  <button
+                    type="submit"
+                    className="propBtn propBtn--primary"
+                    disabled={!form.title.trim() || submitting || deleting}
+                  >
+                    {submitting ? "Saving..." : "Save"}
+                  </button>
+                </>
+              )
             ) : (
-            <>
+              <>
                 <button
-                type="button"
-                className="propBtn propBtn--danger"
-                disabled={submitting || deleting}
-                onClick={() => setShowDeleteConfirm(true)}
+                  type="button"
+                  className="propBtn"
+                  onClick={onClose}
+                  disabled={submitting}
                 >
-                Delete
+                  Cancel
                 </button>
 
                 <button
-                type="submit"
-                className="propBtn propBtn--primary"
-                disabled={!form.title.trim() || submitting || deleting}
+                  type="submit"
+                  className="propBtn propBtn--primary"
+                  disabled={!form.title.trim() || submitting}
                 >
-                {submitting ? "Saving..." : "Save"}
+                  {submitting ? "Adding..." : "Add"}
                 </button>
-            </>
-            )
-        ) : (
-            <>
-            <button type="button" className="propBtn" onClick={onClose} disabled={submitting}>
-                Cancel
-            </button>
-
-            <button type="submit" className="propBtn propBtn--primary" disabled={!form.title.trim() || submitting}>
-                {submitting ? "Adding..." : "Add"}
-            </button>
-            </>
-        )}
-        </div>
+              </>
+            )}
+          </div>
         </form>
       </div>
     </div>

--- a/frontend/src/modals/SignUpModal.css
+++ b/frontend/src/modals/SignUpModal.css
@@ -184,7 +184,10 @@
   color: var(--text);
   padding: 12px 18px;
   cursor: pointer;
-  transition: background 180ms ease, color 180ms ease, border-color 180ms ease;
+  transition:
+    background 180ms ease,
+    color 180ms ease,
+    border-color 180ms ease;
 }
 
 .signupModal__btn:hover {

--- a/frontend/src/modals/SignUpModal.jsx
+++ b/frontend/src/modals/SignUpModal.jsx
@@ -1,422 +1,426 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Link, useLocation, useNavigate } from "react-router-dom";
 import { register } from "../api";
-import "./SignUpModal.css"
+import "./SignUpModal.css";
 
 const STEP_INFO = 0;
 const STEP_PASSWORD = 1;
 const STEP_DONE = 2;
 
 export default function SignUpModal() {
-    const navigate = useNavigate();
-    const location = useLocation();
+  const navigate = useNavigate();
+  const location = useLocation();
 
-    const hasBackground = !!location.state?.backgroundLocation;
-    const forceHomeOnClose = !!location.state?.forceHomeOnClose;
+  const hasBackground = !!location.state?.backgroundLocation;
+  const forceHomeOnClose = !!location.state?.forceHomeOnClose;
 
-    const [step, setStep] = useState(STEP_INFO);
+  const [step, setStep] = useState(STEP_INFO);
 
-    const [form, setForm] = useState({
-        firstName: "",
-        lastName: "",
-        companyName: "",
-        email: "",
-        phone: "",
-        password: "",
-    });
-    const [confirmPassword, setConfirmPassword] = useState("");
+  const [form, setForm] = useState({
+    firstName: "",
+    lastName: "",
+    companyName: "",
+    email: "",
+    phone: "",
+    password: "",
+  });
+  const [confirmPassword, setConfirmPassword] = useState("");
 
-    const [showPassword, setShowPassword] = useState(false);
-    const [showConfirm, setShowConfirm] = useState(false);
+  const [showPassword, setShowPassword] = useState(false);
+  const [showConfirm, setShowConfirm] = useState(false);
 
-    const [loading, setLoading] = useState(false);
-    const [error, setError] = useState("");
-    const [result, setResult] = useState(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+  const [result, setResult] = useState(null);
 
-    const [direction, setDirection] = useState("forward"); // "forward" | "back"
-    const [animKey, setAnimKey] = useState(0);
+  const [direction, setDirection] = useState("forward"); // "forward" | "back"
+  const [animKey, setAnimKey] = useState(0);
 
-    const bg = location.state?.backgroundLocation || { pathname: "/" };
-    const phoneRef = useRef(null);
+  const bg = location.state?.backgroundLocation || { pathname: "/" };
+  const phoneRef = useRef(null);
 
-    function goStep(nextStep) {
-        setDirection(nextStep > step ? "forward" : "back");
-        setStep(nextStep);
-        setAnimKey((k) => k + 1);
+  function goStep(nextStep) {
+    setDirection(nextStep > step ? "forward" : "back");
+    setStep(nextStep);
+    setAnimKey((k) => k + 1);
+  }
+
+  function close() {
+    if (forceHomeOnClose) {
+      navigate("/", { replace: true });
+      return;
     }
+    if (hasBackground) navigate(-1);
+    else navigate("/", { replace: true });
+  }
 
-    function close() {
-        if (forceHomeOnClose) {
-            navigate("/", { replace: true });
-            return;
-        }
-        if (hasBackground) navigate(-1);
-        else navigate("/", { replace: true });
+  useEffect(() => {
+    function onKeyDown(e) {
+      if (e.key === "Escape") close();
     }
-
-    useEffect(() => {
-        function onKeyDown(e) {
-            if (e.key === "Escape") close();
-        }
-        window.addEventListener("keydown", onKeyDown);
-        return () => window.removeEventListener("keydown", onKeyDown);
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [hasBackground, forceHomeOnClose]);
+  }, [hasBackground, forceHomeOnClose]);
 
-    const infoValid = useMemo(() => {
-        return (
-            form.firstName.trim() && 
-            form.lastName.trim() &&
-            form.companyName.trim() &&
-            form.email.trim() &&
-            form.phone.trim()
-        );
-    }, [form]);
-
-    const passwordValid = useMemo(() => {
-        // backend requires minLength 8 for password
-        return form.password.length >= 8 && form.password === confirmPassword;
-    }, [form.password, confirmPassword]);
-
-    function updateField(key) {
-        return (e) => setForm((p) => ({ ...p, [key]: e.target.value }));
-    }
-
-    function formatPhoneDigits(digits) {
-        if (!digits) return "";
-
-        // allow up to 11 digits, but only show +1 if it's exactly 11 and starts with 1
-        const raw = digits.slice(0, 11);
-
-        let prefix = "";
-        let d = raw;
-
-        if (raw.length === 11 && raw.startsWith("1")) {
-            prefix = "+1 ";
-            d = raw.slice(1); // now 10 digits
-        } else {
-            d = raw.slice(0, 10);
-        }
-
-        const a = d.slice(0, 3);
-        const b = d.slice(3, 6);
-        const c = d.slice(6, 10);
-
-        if (d.length <= 3) return `(${a}`;
-        if (d.length <= 6) return `${prefix}(${a}) ${b}`;
-        return `${prefix}(${a}) ${b}-${c}`;
-    }
-
-    function cursorPosFromDigitCount(formatted, digitCount) {
-        if (digitCount <= 0) return 0;
-        let count = 0;
-
-        for (let i = 0; i < formatted.length; i++) {
-            if (/\d/.test(formatted[i])) count++;
-            if (count === digitCount) return i + 1;
-        }
-        return formatted.length;
-    }
-
-    function handlePhoneChange(e) {
-        const inputValue = e.target.value;
-        const cursor = e.target.selectionStart ?? inputValue.length;
-
-        const digits = inputValue.replace(/\D/g, "").slice(0, 11);
-        const digitsBeforeCursor = (inputValue.slice(0, cursor).match(/\d/g) || []).length;
-
-        const formatted = formatPhoneDigits(digits);
-
-        setForm((p) => ({ ...p, phone: formatted }));
-
-        window.requestAnimationFrame(() => {
-            const el = phoneRef.current;
-            if (!el) return;
-            const newPos = cursorPosFromDigitCount(formatted, digitsBeforeCursor);
-            el.setSelectionRange(newPos, newPos);
-        });
-    }
-
-    async function handleSubmit(e) {
-        e.preventDefault();
-        setError("");
-
-        if (step === STEP_INFO) {
-            if (!infoValid) {
-                setError("Fill out all fields to continue.");
-                return;
-            }
-            goStep(STEP_PASSWORD);
-            return;
-        }
-
-        if (step === STEP_PASSWORD) {
-            if (form.password.length < 8) {
-                setError("Password must be at least 8 characters.");
-                return;
-            }
-            if (form.password !== confirmPassword) {
-                setError("Password do not match.");
-                return;
-            }
-
-            setLoading(true);
-            try {
-                // RegisterRequestDto requires: firstName, lastName, companyName, email, phone, password
-                const res = await register({
-                    firstName: form.firstName.trim(),
-                    lastName: form.lastName.trim(),
-                    companyName: form.companyName.trim(),
-                    email: form.email.trim(),
-                    phone: form.phone.trim(),
-                    password: form.password,
-                });
-
-                setResult(res);
-                goStep(STEP_DONE);
-            } catch (err) {
-                setError(err?.data?.message || err?.message || "Sign up failed");
-            } finally {
-                setLoading(false);
-            }
-            return;
-        }
-
-        // STEP_DONE
-        close();
-    }
-
-    const modalTitle =
-      step === STEP_PASSWORD ? "Set password" : step === STEP_DONE ? "Thank you" : "Sign Up";
-
+  const infoValid = useMemo(() => {
     return (
-        <div className="signupOverlay" onMouseDown={close}>
-            <div className="signupModal" onMouseDown={(e) => e.stopPropagation()}>
-                <div className="signupModal__header">
-                    <div className="signupModal__headerLeft">
-                        <h2 className="signupModal__title">
-                            {modalTitle}
-                        </h2>
+      form.firstName.trim() &&
+      form.lastName.trim() &&
+      form.companyName.trim() &&
+      form.email.trim() &&
+      form.phone.trim()
+    );
+  }, [form]);
 
-                        {step !== STEP_DONE && (
-                            <div className="signupModal__step">
-                                Step {step + 1} of 2
-                            </div>
-                        )}
-                    </div>
+  const passwordValid = useMemo(() => {
+    // backend requires minLength 8 for password
+    return form.password.length >= 8 && form.password === confirmPassword;
+  }, [form.password, confirmPassword]);
 
-                    <div
-                        className="signupModal__close"
-                        onClick={close}
-                        role="button"
-                        tabIndex={0}
-                        aria-label="Close signup"
-                        onKeyDown={(e) => {
-                            if (e.key === "Enter" || e.key === " ") close();
-                        }}
-                    >
-                        ✕
-                    </div>
-                </div>
+  function updateField(key) {
+    return (e) => setForm((p) => ({ ...p, [key]: e.target.value }));
+  }
 
+  function formatPhoneDigits(digits) {
+    if (!digits) return "";
 
-                <form className="signupModal__form" onSubmit={handleSubmit}>
-                    <div className="signupModal__contentWrap">
-                        <div
-                            key={animKey}
-                            className={`signupModal__content signupModal__content--${direction}`}>
-                            {step === STEP_INFO && (
-                                <>
-                                    <div className="field">
-                                        <input
-                                            className="field__input"
-                                            value={form.firstName}
-                                            onChange={updateField("firstName")}
-                                            placeholder=" "
-                                            autoComplete="given-name"
-                                        />
-                                        <label className="field__label">First name</label>
-                                    </div>
+    // allow up to 11 digits, but only show +1 if it's exactly 11 and starts with 1
+    const raw = digits.slice(0, 11);
 
-                                    <div className="field">
-                                        <input
-                                            className="field__input"
-                                            value={form.lastName}
-                                            onChange={updateField("lastName")}
-                                            placeholder=" "
-                                            autoComplete="family-name"
-                                        />
-                                        <label className="field__label">Last name</label>
-                                    </div>
+    let prefix = "";
+    let d = raw;
 
-                                    <div className="field">
-                                        <input
-                                            className="field__input"
-                                            value={form.companyName}
-                                            onChange={updateField("companyName")}
-                                            placeholder=" "
-                                            autoComplete="organization"
-                                        />
-                                        <label className="field__label">Company name</label>
-                                    </div>
+    if (raw.length === 11 && raw.startsWith("1")) {
+      prefix = "+1 ";
+      d = raw.slice(1); // now 10 digits
+    } else {
+      d = raw.slice(0, 10);
+    }
 
-                                    <div className="field">
-                                        <input
-                                            className="field__input"
-                                            value={form.email}
-                                            onChange={updateField("email")}
-                                            placeholder=" "
-                                            type="email"
-                                            autoComplete="email"
-                                        />
-                                        <label className="field__label">Email</label>
-                                    </div>
+    const a = d.slice(0, 3);
+    const b = d.slice(3, 6);
+    const c = d.slice(6, 10);
 
-                                    <div className="field">
-                                        <input
-                                            ref={phoneRef}
-                                            className="field__input"
-                                            value={form.phone}
-                                            onChange={handlePhoneChange}
-                                            placeholder=" "
-                                            type="tel"
-                                            inputMode="tel"
-                                            autoComplete="tel"
-                                        />
-                                        <label className="field__label">Phone</label>
-                                    </div>
+    if (d.length <= 3) return `(${a}`;
+    if (d.length <= 6) return `${prefix}(${a}) ${b}`;
+    return `${prefix}(${a}) ${b}-${c}`;
+  }
 
-                                    {step === STEP_INFO && (
-                                        <div className="signupModal__hint">
-                                            Please fill out the information above.
-                                        </div>
-                                    )}
-                                    <div className="signupModal__alt">
-                                        Already have an account?{" "}
-                                        <Link
-                                            className="signupModal__altLink"
-                                            to="/login"
-                                            replace
-                                            state={{ modal: true, backgroundLocation: bg }}
-                                        >
-                                            <span className="signupModal__altLinkInner">
-                                                Login
-                                            </span>
-                                        </Link>
-                                    </div>
-                                </>
-                            )}
+  function cursorPosFromDigitCount(formatted, digitCount) {
+    if (digitCount <= 0) return 0;
+    let count = 0;
 
-                            {step === STEP_PASSWORD && (
-                                <>
-                                    <div className="field field--password">
-                                        <input
-                                            className="field__input"
-                                            value={form.password}
-                                            onChange={updateField("password")}
-                                            placeholder=" "
-                                            type={showPassword ? "text" : "password"}
-                                            autoComplete="new-password"
-                                        />
-                                        <label className="field__label">Password</label>
+    for (let i = 0; i < formatted.length; i++) {
+      if (/\d/.test(formatted[i])) count++;
+      if (count === digitCount) return i + 1;
+    }
+    return formatted.length;
+  }
 
-                                        <button
-                                            type="button"
-                                            className="field__toggle"
-                                            tabIndex={-1}
-                                            onClick={() => setShowPassword((v) => !v)}
-                                            aria-label={showPassword ? "Hide password" : "Show password"}
-                                        >
-                                            <span className="material-symbols-outlined">
-                                                {showPassword ? "visibility" : "visibility_off"}
-                                            </span>
-                                        </button>
-                                    </div>
+  function handlePhoneChange(e) {
+    const inputValue = e.target.value;
+    const cursor = e.target.selectionStart ?? inputValue.length;
 
-                                    <div className="field field--password">
-                                        <input
-                                            className="field__input"
-                                            value={confirmPassword}
-                                            onChange={(e) => setConfirmPassword(e.target.value)}
-                                            placeholder=" "
-                                            type={showConfirm ? "text" : "password"}
-                                            autoComplete="new-password"
-                                        />
-                                        <label className="field__label">Confirm password</label>
+    const digits = inputValue.replace(/\D/g, "").slice(0, 11);
+    const digitsBeforeCursor = (inputValue.slice(0, cursor).match(/\d/g) || [])
+      .length;
 
-                                        <button
-                                            type="button"
-                                            className="field__toggle"
-                                            tabIndex={-1}
-                                            onClick={() => setShowConfirm((v) => !v)}
-                                            aria-label={showConfirm ? "Hide password" : "Show password"}
-                                        >
-                                            <span className="material-symbols-outlined">
-                                                {showConfirm ? "visibility" : "visibility_off"}
-                                            </span>
-                                        </button>
-                                    </div>
-                                </>
-                            )}
+    const formatted = formatPhoneDigits(digits);
 
-                            {step === STEP_DONE && (
-                                <div className="signupModal__done">
-                                    <p>
-                                        Your request has been received. Please wait until the Megna team reaches out to you.
-                                    </p>
+    setForm((p) => ({ ...p, phone: formatted }));
 
-                                    {result?.email && (
-                                        <p className="signupModal__doneMeta">
-                                            {result.email} {result.status ? `• ${result.status}` : ""}
-                                        </p>
-                                    )}
+    window.requestAnimationFrame(() => {
+      const el = phoneRef.current;
+      if (!el) return;
+      const newPos = cursorPosFromDigitCount(formatted, digitsBeforeCursor);
+      el.setSelectionRange(newPos, newPos);
+    });
+  }
 
-                                    <button className="signupModal__btn" type="submit">
-                                        Close
-                                    </button>
-                                </div>
-                            )}
-                            {error && <div className="signupModal__error">{error}</div>}
+  async function handleSubmit(e) {
+    e.preventDefault();
+    setError("");
 
-                            {step === STEP_INFO && (
-                                <div className="signupModal__actions signupModal__actions--single">
-                                    <button
-                                        className="signupModal__btn"
-                                        type="submit"
-                                        disabled={loading || !infoValid}
-                                    >
-                                        {loading ? "Submitting..." : "Continue"}
-                                    </button>
-                                </div>
-                            )}
+    if (step === STEP_INFO) {
+      if (!infoValid) {
+        setError("Fill out all fields to continue.");
+        return;
+      }
+      goStep(STEP_PASSWORD);
+      return;
+    }
 
-                            {step === STEP_PASSWORD && (
-                                <div className="signupModal__actions">
-                                    <button
-                                        type="button"
-                                        className="signupModal__btn signupModal__btn--secondary"
-                                        onClick={() => {
-                                            setError("");
-                                            goStep(STEP_INFO);
-                                        }}
-                                        disabled={loading}
-                                    >
-                                        Back
-                                    </button>
+    if (step === STEP_PASSWORD) {
+      if (form.password.length < 8) {
+        setError("Password must be at least 8 characters.");
+        return;
+      }
+      if (form.password !== confirmPassword) {
+        setError("Password do not match.");
+        return;
+      }
 
-                                    <button
-                                        className="signupModal__btn"
-                                        type="submit"
-                                        disabled={loading || !passwordValid}
-                                    >
-                                        {loading ? "Submitting..." : "Get Started"}
-                                    </button>
-                                </div>
-                            )}
-                        </div>
-                    </div>
-                </form>
-            </div>
+      setLoading(true);
+      try {
+        // RegisterRequestDto requires: firstName, lastName, companyName, email, phone, password
+        const res = await register({
+          firstName: form.firstName.trim(),
+          lastName: form.lastName.trim(),
+          companyName: form.companyName.trim(),
+          email: form.email.trim(),
+          phone: form.phone.trim(),
+          password: form.password,
+        });
+
+        setResult(res);
+        goStep(STEP_DONE);
+      } catch (err) {
+        setError(err?.data?.message || err?.message || "Sign up failed");
+      } finally {
+        setLoading(false);
+      }
+      return;
+    }
+
+    // STEP_DONE
+    close();
+  }
+
+  const modalTitle =
+    step === STEP_PASSWORD
+      ? "Set password"
+      : step === STEP_DONE
+        ? "Thank you"
+        : "Sign Up";
+
+  return (
+    <div className="signupOverlay" onMouseDown={close}>
+      <div className="signupModal" onMouseDown={(e) => e.stopPropagation()}>
+        <div className="signupModal__header">
+          <div className="signupModal__headerLeft">
+            <h2 className="signupModal__title">{modalTitle}</h2>
+
+            {step !== STEP_DONE && (
+              <div className="signupModal__step">Step {step + 1} of 2</div>
+            )}
+          </div>
+
+          <div
+            className="signupModal__close"
+            onClick={close}
+            role="button"
+            tabIndex={0}
+            aria-label="Close signup"
+            onKeyDown={(e) => {
+              if (e.key === "Enter" || e.key === " ") close();
+            }}
+          >
+            ✕
+          </div>
         </div>
-    )
+
+        <form className="signupModal__form" onSubmit={handleSubmit}>
+          <div className="signupModal__contentWrap">
+            <div
+              key={animKey}
+              className={`signupModal__content signupModal__content--${direction}`}
+            >
+              {step === STEP_INFO && (
+                <>
+                  <div className="field">
+                    <input
+                      className="field__input"
+                      value={form.firstName}
+                      onChange={updateField("firstName")}
+                      placeholder=" "
+                      autoComplete="given-name"
+                    />
+                    <label className="field__label">First name</label>
+                  </div>
+
+                  <div className="field">
+                    <input
+                      className="field__input"
+                      value={form.lastName}
+                      onChange={updateField("lastName")}
+                      placeholder=" "
+                      autoComplete="family-name"
+                    />
+                    <label className="field__label">Last name</label>
+                  </div>
+
+                  <div className="field">
+                    <input
+                      className="field__input"
+                      value={form.companyName}
+                      onChange={updateField("companyName")}
+                      placeholder=" "
+                      autoComplete="organization"
+                    />
+                    <label className="field__label">Company name</label>
+                  </div>
+
+                  <div className="field">
+                    <input
+                      className="field__input"
+                      value={form.email}
+                      onChange={updateField("email")}
+                      placeholder=" "
+                      type="email"
+                      autoComplete="email"
+                    />
+                    <label className="field__label">Email</label>
+                  </div>
+
+                  <div className="field">
+                    <input
+                      ref={phoneRef}
+                      className="field__input"
+                      value={form.phone}
+                      onChange={handlePhoneChange}
+                      placeholder=" "
+                      type="tel"
+                      inputMode="tel"
+                      autoComplete="tel"
+                    />
+                    <label className="field__label">Phone</label>
+                  </div>
+
+                  {step === STEP_INFO && (
+                    <div className="signupModal__hint">
+                      Please fill out the information above.
+                    </div>
+                  )}
+                  <div className="signupModal__alt">
+                    Already have an account?{" "}
+                    <Link
+                      className="signupModal__altLink"
+                      to="/login"
+                      replace
+                      state={{ modal: true, backgroundLocation: bg }}
+                    >
+                      <span className="signupModal__altLinkInner">Login</span>
+                    </Link>
+                  </div>
+                </>
+              )}
+
+              {step === STEP_PASSWORD && (
+                <>
+                  <div className="field field--password">
+                    <input
+                      className="field__input"
+                      value={form.password}
+                      onChange={updateField("password")}
+                      placeholder=" "
+                      type={showPassword ? "text" : "password"}
+                      autoComplete="new-password"
+                    />
+                    <label className="field__label">Password</label>
+
+                    <button
+                      type="button"
+                      className="field__toggle"
+                      tabIndex={-1}
+                      onClick={() => setShowPassword((v) => !v)}
+                      aria-label={
+                        showPassword ? "Hide password" : "Show password"
+                      }
+                    >
+                      <span className="material-symbols-outlined">
+                        {showPassword ? "visibility" : "visibility_off"}
+                      </span>
+                    </button>
+                  </div>
+
+                  <div className="field field--password">
+                    <input
+                      className="field__input"
+                      value={confirmPassword}
+                      onChange={(e) => setConfirmPassword(e.target.value)}
+                      placeholder=" "
+                      type={showConfirm ? "text" : "password"}
+                      autoComplete="new-password"
+                    />
+                    <label className="field__label">Confirm password</label>
+
+                    <button
+                      type="button"
+                      className="field__toggle"
+                      tabIndex={-1}
+                      onClick={() => setShowConfirm((v) => !v)}
+                      aria-label={
+                        showConfirm ? "Hide password" : "Show password"
+                      }
+                    >
+                      <span className="material-symbols-outlined">
+                        {showConfirm ? "visibility" : "visibility_off"}
+                      </span>
+                    </button>
+                  </div>
+                </>
+              )}
+
+              {step === STEP_DONE && (
+                <div className="signupModal__done">
+                  <p>
+                    Your request has been received. Please wait until the Megna
+                    team reaches out to you.
+                  </p>
+
+                  {result?.email && (
+                    <p className="signupModal__doneMeta">
+                      {result.email} {result.status ? `• ${result.status}` : ""}
+                    </p>
+                  )}
+
+                  <button className="signupModal__btn" type="submit">
+                    Close
+                  </button>
+                </div>
+              )}
+              {error && <div className="signupModal__error">{error}</div>}
+
+              {step === STEP_INFO && (
+                <div className="signupModal__actions signupModal__actions--single">
+                  <button
+                    className="signupModal__btn"
+                    type="submit"
+                    disabled={loading || !infoValid}
+                  >
+                    {loading ? "Submitting..." : "Continue"}
+                  </button>
+                </div>
+              )}
+
+              {step === STEP_PASSWORD && (
+                <div className="signupModal__actions">
+                  <button
+                    type="button"
+                    className="signupModal__btn signupModal__btn--secondary"
+                    onClick={() => {
+                      setError("");
+                      goStep(STEP_INFO);
+                    }}
+                    disabled={loading}
+                  >
+                    Back
+                  </button>
+
+                  <button
+                    className="signupModal__btn"
+                    type="submit"
+                    disabled={loading || !passwordValid}
+                  >
+                    {loading ? "Submitting..." : "Get Started"}
+                  </button>
+                </div>
+              )}
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
 }

--- a/frontend/src/pages/admin/AdminPropertiesPage.css
+++ b/frontend/src/pages/admin/AdminPropertiesPage.css
@@ -66,7 +66,10 @@
   cursor: pointer;
   display: grid;
   place-items: center;
-  transition: background 180ms ease, color 180ms ease, border-color 180ms ease;
+  transition:
+    background 180ms ease,
+    color 180ms ease,
+    border-color 180ms ease;
 }
 
 .adminProps__iconBtn:hover {
@@ -186,7 +189,10 @@
   cursor: pointer;
   display: inline-grid;
   place-items: center;
-  transition: background 180ms ease, color 180ms ease, border-color 180ms ease;
+  transition:
+    background 180ms ease,
+    color 180ms ease,
+    border-color 180ms ease;
 }
 
 .adminProps__editBtn:hover {
@@ -219,7 +225,10 @@
   color: var(--admin-ink);
   padding: 8px 12px;
   cursor: pointer;
-  transition: background 180ms ease, color 180ms ease, border-color 180ms ease;
+  transition:
+    background 180ms ease,
+    color 180ms ease,
+    border-color 180ms ease;
 }
 
 .adminProps__pageBtn:hover {

--- a/frontend/src/pages/admin/AdminPropertiesPage.jsx
+++ b/frontend/src/pages/admin/AdminPropertiesPage.jsx
@@ -1,5 +1,11 @@
 import { useEffect, useMemo, useState } from "react";
-import { createProperty, deleteProperty, getPropertyId, searchProperties, updateProperty } from "../../api/propertyApi";
+import {
+  createProperty,
+  deleteProperty,
+  getPropertyId,
+  searchProperties,
+  updateProperty,
+} from "../../api/propertyApi";
 import "./AdminPropertiesPage.css";
 import PropertyUpsertModal from "../../modals/PropertyUpsertModal";
 
@@ -58,8 +64,18 @@ function prettyEnum(v) {
 function buildPages(current, total) {
   if (total <= 7) return Array.from({ length: total }, (_, i) => i);
 
-  const pages = new Set([0, 1, total - 2, total - 1, current - 1, current, current + 1]);
-  const sorted = [...pages].filter((p) => p >= 0 && p < total).sort((a, b) => a - b);
+  const pages = new Set([
+    0,
+    1,
+    total - 2,
+    total - 1,
+    current - 1,
+    current,
+    current + 1,
+  ]);
+  const sorted = [...pages]
+    .filter((p) => p >= 0 && p < total)
+    .sort((a, b) => a - b);
 
   const out = [];
   for (let i = 0; i < sorted.length; i++) {
@@ -104,7 +120,7 @@ function Pagination({ page, totalPages, onPageChange }) {
             >
               {it + 1}
             </button>
-          )
+          ),
         )}
       </div>
 
@@ -208,7 +224,7 @@ export default function AdminPropertiesPage() {
     const s = String(v ?? "").trim();
     return s.length ? s : null;
   }
-  
+
   function parseNum(v) {
     const raw = String(v ?? "").trim();
     if (!raw) return null;
@@ -216,18 +232,18 @@ export default function AdminPropertiesPage() {
     const n = Number(normalized);
     return Number.isFinite(n) ? n : null;
   }
-  
+
   function parseIntNum(v) {
     const n = parseNum(v);
     if (n === null) return null;
     const i = Number.parseInt(String(n), 10);
     return Number.isFinite(i) ? i : null;
   }
-  
+
   async function handleAddSubmit(form) {
     setAddSubmitting(true);
     setAddError("");
-  
+
     try {
       const dto = {
         status: form.status,
@@ -237,31 +253,31 @@ export default function AdminPropertiesPage() {
         city: cleanStr(form.city),
         state: cleanStr(form.state),
         zip: cleanStr(form.zip),
-  
+
         askingPrice: parseNum(form.askingPrice),
         arv: parseNum(form.arv),
         estRepairs: parseNum(form.estRepairs),
-  
+
         beds: parseIntNum(form.beds),
         baths: parseNum(form.baths),
         livingAreaSqft: parseIntNum(form.livingAreaSqft),
         yearBuilt: parseIntNum(form.yearBuilt),
         roofAge: parseIntNum(form.roofAge),
         hvac: parseIntNum(form.hvac),
-  
+
         occupancyStatus: cleanStr(form.occupancyStatus),
         exitStrategy: cleanStr(form.exitStrategy),
         closingTerms: cleanStr(form.closingTerms),
-  
+
         description: cleanStr(form.description),
-  
+
         // leave these null for MVP
         photos: null,
         saleComps: null,
       };
-  
+
       await createProperty(dto);
-  
+
       setAddOpen(false);
       setPage(0);
       setRefreshKey((k) => k + 1); // forces reload even if already on page 0
@@ -270,7 +286,7 @@ export default function AdminPropertiesPage() {
     } finally {
       setAddSubmitting(false);
     }
-  }  
+  }
 
   function formToUpsertDto(form) {
     return {
@@ -281,24 +297,24 @@ export default function AdminPropertiesPage() {
       city: cleanStr(form.city),
       state: cleanStr(form.state),
       zip: cleanStr(form.zip),
-  
+
       askingPrice: parseNum(form.askingPrice),
       arv: parseNum(form.arv),
       estRepairs: parseNum(form.estRepairs),
-  
+
       beds: parseIntNum(form.beds),
       baths: parseNum(form.baths),
       livingAreaSqft: parseIntNum(form.livingAreaSqft),
       yearBuilt: parseIntNum(form.yearBuilt),
       roofAge: parseIntNum(form.roofAge),
       hvac: parseIntNum(form.hvac),
-  
+
       occupancyStatus: cleanStr(form.occupancyStatus),
       exitStrategy: cleanStr(form.exitStrategy),
       closingTerms: cleanStr(form.closingTerms),
-  
+
       description: cleanStr(form.description),
-  
+
       photos: null,
       saleComps: null,
     };
@@ -308,7 +324,7 @@ export default function AdminPropertiesPage() {
     setEditLoadError("");
     setEditError("");
     setEditSubmitting(false);
-  
+
     try {
       const full = await getPropertyId(id);
       setEditId(id);
@@ -318,21 +334,21 @@ export default function AdminPropertiesPage() {
       setEditLoadError(e?.message || "Failed to load property details.");
     }
   }
-  
+
   async function handleEditSubmit(form) {
     if (!editId) return;
-  
+
     setEditSubmitting(true);
     setEditError("");
-  
+
     try {
       const dto = formToUpsertDto(form);
       await updateProperty(editId, dto);
-  
+
       setEditOpen(false);
       setEditId(null);
       setEditInitial(null);
-  
+
       setRefreshKey((k) => k + 1); // refresh list, keep same page
     } catch (e) {
       setEditError(e?.message || "Failed to update property.");
@@ -343,19 +359,19 @@ export default function AdminPropertiesPage() {
 
   async function handleEditDelete() {
     if (!editId) return;
-  
+
     setEditDeleting(true);
     setEditDeleteError("");
-  
+
     try {
       await deleteProperty(editId);
-  
+
       setEditOpen(false);
       setEditId(null);
       setEditInitial(null);
       setEditError("");
       setEditLoadError("");
-  
+
       setPage(0);
       setRefreshKey((k) => k + 1);
     } catch (e) {
@@ -363,7 +379,7 @@ export default function AdminPropertiesPage() {
     } finally {
       setEditDeleting(false);
     }
-  }  
+  }
 
   return (
     <section className="adminProps">
@@ -371,7 +387,10 @@ export default function AdminPropertiesPage() {
         <h1 className="adminProps__title">Properties</h1>
       </header>
 
-      <form className="adminProps__filters" onSubmit={(e) => e.preventDefault()}>
+      <form
+        className="adminProps__filters"
+        onSubmit={(e) => e.preventDefault()}
+      >
         <div className="adminProps__filterRow">
           <label className="adminProps__filter">
             <span className="adminProps__label">Occupancy Status</span>
@@ -439,7 +458,7 @@ export default function AdminPropertiesPage() {
             title="Add Property"
             aria-label="Add Property"
             onClick={() => {
-              setAddOpen(true)
+              setAddOpen(true);
             }}
           >
             <span className="material-symbols-outlined">add_home_work</span>
@@ -449,7 +468,9 @@ export default function AdminPropertiesPage() {
 
       <div className="adminProps__below">
         {!hasRows ? (
-          <div className={`adminProps__notice ${error ? "adminProps__notice--error" : ""}`}>
+          <div
+            className={`adminProps__notice ${error ? "adminProps__notice--error" : ""}`}
+          >
             {tableCaption}
           </div>
         ) : (
@@ -477,20 +498,32 @@ export default function AdminPropertiesPage() {
                     <tr key={p.id}>
                       <td className="adminProps__tdAddress">
                         <div className="adminProps__addrMain">{p.street1}</div>
-                        <div className="adminProps__addrSub">{fullAddress(p)}</div>
+                        <div className="adminProps__addrSub">
+                          {fullAddress(p)}
+                        </div>
                       </td>
 
-                      <td className="adminProps__tdRight">{money(p.askingPrice)}</td>
+                      <td className="adminProps__tdRight">
+                        {money(p.askingPrice)}
+                      </td>
                       <td className="adminProps__tdRight">{money(p.arv)}</td>
-                      <td className="adminProps__tdRight">{money(p.estRepairs)}</td>
-                      <td className="adminProps__tdCenter">{prettyEnum(p.exitStrategy)}</td>
+                      <td className="adminProps__tdRight">
+                        {money(p.estRepairs)}
+                      </td>
+                      <td className="adminProps__tdCenter">
+                        {prettyEnum(p.exitStrategy)}
+                      </td>
                       <td className="adminProps__tdRight">
                         {p.livingAreaSqft?.toLocaleString("en-US") ?? "—"}
                       </td>
                       <td className="adminProps__tdCenter">{p.beds ?? "—"}</td>
                       <td className="adminProps__tdCenter">{p.baths ?? "—"}</td>
-                      <td className="adminProps__tdCenter">{p.yearBuilt ?? "—"}</td>
-                      <td className="adminProps__tdCenter">{prettyEnum(p.status)}</td>
+                      <td className="adminProps__tdCenter">
+                        {p.yearBuilt ?? "—"}
+                      </td>
+                      <td className="adminProps__tdCenter">
+                        {prettyEnum(p.status)}
+                      </td>
 
                       <td className="adminProps__tdIcon">
                         <button
@@ -500,7 +533,9 @@ export default function AdminPropertiesPage() {
                           aria-label={`Edit property ${p.id}`}
                           onClick={() => openEditModal(p.id)}
                         >
-                          <span className="material-symbols-outlined">edit</span>
+                          <span className="material-symbols-outlined">
+                            edit
+                          </span>
                         </button>
                       </td>
                     </tr>
@@ -509,7 +544,11 @@ export default function AdminPropertiesPage() {
               </table>
             </div>
 
-            <Pagination page={page} totalPages={pageMeta.totalPages} onPageChange={setPage} />
+            <Pagination
+              page={page}
+              totalPages={pageMeta.totalPages}
+              onPageChange={setPage}
+            />
           </>
         )}
       </div>
@@ -518,28 +557,30 @@ export default function AdminPropertiesPage() {
         open={addOpen}
         mode="add"
         onClose={() => {
-            if (!addSubmitting) setAddOpen(false);
+          if (!addSubmitting) setAddOpen(false);
         }}
         onSubmit={handleAddSubmit}
         submitting={addSubmitting}
         submitError={addError}
       />
 
-        {editLoadError ? (
-        <div className="adminProps__notice adminProps__notice--error">{editLoadError}</div>
-        ) : null}
+      {editLoadError ? (
+        <div className="adminProps__notice adminProps__notice--error">
+          {editLoadError}
+        </div>
+      ) : null}
 
-        <PropertyUpsertModal
+      <PropertyUpsertModal
         open={editOpen}
         mode="edit"
         initialValue={editInitial}
         onClose={() => {
-            if (editSubmitting || editDeleting) return;
-            setEditOpen(false);
-            setEditId(null);
-            setEditInitial(null);
-            setEditError("");
-            setEditDeleteError("");
+          if (editSubmitting || editDeleting) return;
+          setEditOpen(false);
+          setEditId(null);
+          setEditInitial(null);
+          setEditError("");
+          setEditDeleteError("");
         }}
         onSubmit={handleEditSubmit}
         submitting={editSubmitting}
@@ -547,7 +588,7 @@ export default function AdminPropertiesPage() {
         onDelete={handleEditDelete}
         deleting={editDeleting}
         deleteError={editDeleteError}
-        />
+      />
     </section>
   );
 }


### PR DESCRIPTION
### Motivation
- Improve readability and maintainability of several frontend modal and admin page files by applying a consistent formatting and organization pass without changing behavior or UI.
- Normalize import formatting, JSX structure, and CSS rule ordering so future edits are easier and diffs are smaller.

### Description
- Reformatted and reflowed code in these files with no logic, DOM, className, or CSS value changes: `frontend/src/modals/PropertyUpsertModal.jsx`, `frontend/src/modals/PropertyUpsertModal.css`, `frontend/src/modals/SignUpModal.jsx`, `frontend/src/modals/SignUpModal.css`, `frontend/src/pages/admin/AdminPropertiesPage.jsx`, and `frontend/src/pages/admin/AdminPropertiesPage.css`.
- Normalized import blocks (wrapped long imports), adjusted indentation and line breaks in JSX (organized blocks and wrapped attributes), and grouped CSS rules for consistent ordering and property layout.
- Tidied multi-line JSX/HTML regions (tables, forms, modal markup) to consistent line-wrapping and spacing, and made minor whitespace-only changes (no behavioral changes).
- Applied Prettier formatting across the modified files to enforce consistent style.

### Testing
- Ran `npx prettier --check` on the modified files and it passed (all files match Prettier code style).
- Ran `npx prettier --write` to apply formatting; files were updated accordingly.
- Ran `npm --prefix frontend run lint` (ESLint) which reported failures: two `react-hooks/set-state-in-effect` errors in `PropertyUpsertModal.jsx` related to calling `setState` synchronously inside effects; these are lint-rule issues that existed in the logic and were not changed by this formatting-only pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991534a06b0832cb13a09d62e93d980)