### PR TITLE
Remove Admin Properties title and separate filters from table

### DIFF
--- a/frontend/src/pages/admin/AdminPropertiesPage.css
+++ b/frontend/src/pages/admin/AdminPropertiesPage.css
@@ -7,19 +7,6 @@
   color: var(--admin-ink);
 }
 
-.adminProps__header {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  margin-bottom: 12px;
-}
-
-.adminProps__title {
-  margin: 0;
-  font-size: 28px;
-  letter-spacing: 0.2px;
-}
-
 .adminProps__filters {
   border: 1px solid var(--admin-border);
   padding: 12px;
@@ -81,9 +68,12 @@
   font-size: 20px;
 }
 
+.adminProps__tableSection {
+  margin-top: 14px;
+}
+
 .adminProps__below {
   border: 1px solid var(--admin-border);
-  border-top: none;
   padding: 16px 12px;
 }
 
@@ -103,8 +93,6 @@
 }
 
 .adminProps__below {
-  border: 1px solid var(--admin-border);
-  border-top: none;
   background: rgba(255, 255, 255, 0.55);
 }
 

--- a/frontend/src/pages/admin/AdminPropertiesPage.jsx
+++ b/frontend/src/pages/admin/AdminPropertiesPage.jsx
@@ -383,10 +383,6 @@ export default function AdminPropertiesPage() {
 
   return (
     <section className="adminProps">
-      <header className="adminProps__header">
-        <h1 className="adminProps__title">Properties</h1>
-      </header>
-
       <form
         className="adminProps__filters"
         onSubmit={(e) => e.preventDefault()}
@@ -466,91 +462,99 @@ export default function AdminPropertiesPage() {
         </div>
       </form>
 
-      <div className="adminProps__below">
-        {!hasRows ? (
-          <div
-            className={`adminProps__notice ${error ? "adminProps__notice--error" : ""}`}
-          >
-            {tableCaption}
-          </div>
-        ) : (
-          <>
-            <div className="adminProps__tableWrap">
-              <table className="adminProps__table">
-                <thead>
-                  <tr>
-                    <th>Address</th>
-                    <th className="adminProps__thRight">Asking</th>
-                    <th className="adminProps__thRight">ARV</th>
-                    <th className="adminProps__thRight">Repairs</th>
-                    <th className="adminProps__thCenter">Exit</th>
-                    <th className="adminProps__thRight">SqFt</th>
-                    <th className="adminProps__thCenter">Bed</th>
-                    <th className="adminProps__thCenter">Bath</th>
-                    <th className="adminProps__thCenter">Year</th>
-                    <th className="adminProps__thCenter">Status</th>
-                    <th className="adminProps__thIcon"></th>
-                  </tr>
-                </thead>
-
-                <tbody>
-                  {rows.map((p) => (
-                    <tr key={p.id}>
-                      <td className="adminProps__tdAddress">
-                        <div className="adminProps__addrMain">{p.street1}</div>
-                        <div className="adminProps__addrSub">
-                          {fullAddress(p)}
-                        </div>
-                      </td>
-
-                      <td className="adminProps__tdRight">
-                        {money(p.askingPrice)}
-                      </td>
-                      <td className="adminProps__tdRight">{money(p.arv)}</td>
-                      <td className="adminProps__tdRight">
-                        {money(p.estRepairs)}
-                      </td>
-                      <td className="adminProps__tdCenter">
-                        {prettyEnum(p.exitStrategy)}
-                      </td>
-                      <td className="adminProps__tdRight">
-                        {p.livingAreaSqft?.toLocaleString("en-US") ?? "—"}
-                      </td>
-                      <td className="adminProps__tdCenter">{p.beds ?? "—"}</td>
-                      <td className="adminProps__tdCenter">{p.baths ?? "—"}</td>
-                      <td className="adminProps__tdCenter">
-                        {p.yearBuilt ?? "—"}
-                      </td>
-                      <td className="adminProps__tdCenter">
-                        {prettyEnum(p.status)}
-                      </td>
-
-                      <td className="adminProps__tdIcon">
-                        <button
-                          className="adminProps__editBtn"
-                          type="button"
-                          title="Edit"
-                          aria-label={`Edit property ${p.id}`}
-                          onClick={() => openEditModal(p.id)}
-                        >
-                          <span className="material-symbols-outlined">
-                            edit
-                          </span>
-                        </button>
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
+      <div className="adminProps__tableSection">
+        <div className="adminProps__below">
+          {!hasRows ? (
+            <div
+              className={`adminProps__notice ${error ? "adminProps__notice--error" : ""}`}
+            >
+              {tableCaption}
             </div>
+          ) : (
+            <>
+              <div className="adminProps__tableWrap">
+                <table className="adminProps__table">
+                  <thead>
+                    <tr>
+                      <th>Address</th>
+                      <th className="adminProps__thRight">Asking</th>
+                      <th className="adminProps__thRight">ARV</th>
+                      <th className="adminProps__thRight">Repairs</th>
+                      <th className="adminProps__thCenter">Exit</th>
+                      <th className="adminProps__thRight">SqFt</th>
+                      <th className="adminProps__thCenter">Bed</th>
+                      <th className="adminProps__thCenter">Bath</th>
+                      <th className="adminProps__thCenter">Year</th>
+                      <th className="adminProps__thCenter">Status</th>
+                      <th className="adminProps__thIcon"></th>
+                    </tr>
+                  </thead>
 
-            <Pagination
-              page={page}
-              totalPages={pageMeta.totalPages}
-              onPageChange={setPage}
-            />
-          </>
-        )}
+                  <tbody>
+                    {rows.map((p) => (
+                      <tr key={p.id}>
+                        <td className="adminProps__tdAddress">
+                          <div className="adminProps__addrMain">
+                            {p.street1}
+                          </div>
+                          <div className="adminProps__addrSub">
+                            {fullAddress(p)}
+                          </div>
+                        </td>
+
+                        <td className="adminProps__tdRight">
+                          {money(p.askingPrice)}
+                        </td>
+                        <td className="adminProps__tdRight">{money(p.arv)}</td>
+                        <td className="adminProps__tdRight">
+                          {money(p.estRepairs)}
+                        </td>
+                        <td className="adminProps__tdCenter">
+                          {prettyEnum(p.exitStrategy)}
+                        </td>
+                        <td className="adminProps__tdRight">
+                          {p.livingAreaSqft?.toLocaleString("en-US") ?? "—"}
+                        </td>
+                        <td className="adminProps__tdCenter">
+                          {p.beds ?? "—"}
+                        </td>
+                        <td className="adminProps__tdCenter">
+                          {p.baths ?? "—"}
+                        </td>
+                        <td className="adminProps__tdCenter">
+                          {p.yearBuilt ?? "—"}
+                        </td>
+                        <td className="adminProps__tdCenter">
+                          {prettyEnum(p.status)}
+                        </td>
+
+                        <td className="adminProps__tdIcon">
+                          <button
+                            className="adminProps__editBtn"
+                            type="button"
+                            title="Edit"
+                            aria-label={`Edit property ${p.id}`}
+                            onClick={() => openEditModal(p.id)}
+                          >
+                            <span className="material-symbols-outlined">
+                              edit
+                            </span>
+                          </button>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+
+              <Pagination
+                page={page}
+                totalPages={pageMeta.totalPages}
+                onPageChange={setPage}
+              />
+            </>
+          )}
+        </div>
       </div>
 
       <PropertyUpsertModal


### PR DESCRIPTION
### Motivation
- Improve the admin properties page layout by removing the redundant "Properties" header and visually separating the filter bar from the properties table so the UI reads as two distinct sections.

### Description
- Removed the header/title block (`<header className="adminProps__header">` + `<h1 className="adminProps__title">Properties</h1>`) from `AdminPropertiesPage.jsx` so the page begins with the filter bar.
- Introduced a new wrapper `div` with class `adminProps__tableSection` around the table area and moved the existing `.adminProps__below` content inside it to create clear separation between filters and the table.
- Updated `AdminPropertiesPage.css` by removing the unused title/header rules, adding `.adminProps__tableSection { margin-top: 14px; }`, and adjusting the `.adminProps__below` styling so the filter and table containers are visually independent.
- Applied formatting (`prettier`) and small markup cleanups to keep code consistent.

### Testing
- Ran `npx prettier --write src/pages/admin/AdminPropertiesPage.jsx src/pages/admin/AdminPropertiesPage.css` and it completed successfully.
- Ran `cd frontend && npm run lint -- src/pages/admin/AdminPropertiesPage.jsx` and linting passed for the modified JSX file.
- Started the dev server with `cd frontend && npm run dev -- --host 0.0.0.0 --port 4173` and verified the app served correctly.
- Captured a visual verification screenshot of `/admin/properties` using a Playwright script; the screenshot was produced successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69929fc2df08832cb73c2507aa152ecd)