### PR TITLE
Refine admin property filters with compact More dropdown

### DIFF
--- a/backend/src/main/java/com/megna/backend/controllers/PropertyController.java
+++ b/backend/src/main/java/com/megna/backend/controllers/PropertyController.java
@@ -62,10 +62,12 @@ public class PropertyController {
     @GetMapping("/search")
     public Page<PropertyResponseDto> search(
             @RequestParam(required = false) PropertyStatus status,
+            @RequestParam(required = false, name = "q") String query,
             @RequestParam(required = false) String city,
             @RequestParam(required = false) String state,
             @RequestParam(required = false) Integer minBeds,
             @RequestParam(required = false) Integer maxBeds,
+            @RequestParam(required = false) BigDecimal minBaths,
             @RequestParam(required = false) BigDecimal minAskingPrice,
             @RequestParam(required = false) BigDecimal maxAskingPrice,
             @RequestParam(required = false) BigDecimal minArv,
@@ -76,8 +78,8 @@ public class PropertyController {
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
             ) {
         return propertyService.search(
-                status, city, state,
-                minBeds, maxBeds,
+                status, query, city, state,
+                minBeds, maxBeds, minBaths,
                 minAskingPrice, maxAskingPrice,
                 minArv, maxArv,
                 occupancyStatus, exitStrategy, closingTerms,

--- a/backend/src/main/java/com/megna/backend/services/PropertyService.java
+++ b/backend/src/main/java/com/megna/backend/services/PropertyService.java
@@ -54,7 +54,7 @@ public class PropertyService {
 
         if (!admin) {
             return propertyRepository.findAll(
-                    PropertySpecifications.withFilters(ACTIVE, null, null, null, null, null, null, null, null, null, null, null),
+                    PropertySpecifications.withFilters(ACTIVE, null, null, null, null, null, null, null, null, null, null, null, null, null),
                     pageable
             )
                     .map(PropertyMapper::toDto);
@@ -83,10 +83,12 @@ public class PropertyService {
 
     public Page<PropertyResponseDto> search(
             PropertyStatus status,
+            String query,
             String city,
             String state,
             Integer minBeds,
             Integer maxBeds,
+            BigDecimal minBaths,
             BigDecimal minAskingPrice,
             BigDecimal maxAskingPrice,
             BigDecimal minArv,
@@ -102,10 +104,12 @@ public class PropertyService {
 
         var spec = PropertySpecifications.withFilters(
                 effectiveStatus,
+                query,
                 city,
                 state,
                 minBeds,
                 maxBeds,
+                minBaths,
                 minAskingPrice,
                 maxAskingPrice,
                 minArv,

--- a/backend/src/main/java/com/megna/backend/specifications/PropertySpecifications.java
+++ b/backend/src/main/java/com/megna/backend/specifications/PropertySpecifications.java
@@ -15,10 +15,12 @@ public final class PropertySpecifications {
 
     public static Specification<Property> withFilters(
             PropertyStatus status,
+            String query,
             String city,
             String state,
             Integer minBeds,
             Integer maxBeds,
+            BigDecimal minBaths,
             BigDecimal minAskingPrice,
             BigDecimal maxAskingPrice,
             BigDecimal minArv,
@@ -28,10 +30,12 @@ public final class PropertySpecifications {
             ClosingTerms closingTerms
     ) {
         return Specification.where(eqStatus(status))
+                .and(matchesSearchTerm(query))
                 .and(containsIgnoreCase("city", city))
                 .and(containsIgnoreCase("state", state))
                 .and(gteInt("beds", minBeds))
                 .and(lteInt("beds", maxBeds))
+                .and(gteDecimal("baths", minBaths))
                 .and(gteDecimal("askingPrice", minAskingPrice))
                 .and(lteDecimal("askingPrice", maxAskingPrice))
                 .and(gteDecimal("arv", minArv))
@@ -41,6 +45,22 @@ public final class PropertySpecifications {
                 .and(eqClosingTerms(closingTerms));
     }
 
+
+    private static Specification<Property> matchesSearchTerm(String query) {
+        return (root, criteriaQuery, cb) -> {
+            if (query == null || query.isBlank()) return cb.conjunction();
+
+            String normalized = "%" + query.toLowerCase() + "%";
+            return cb.or(
+                    cb.like(cb.lower(root.get("title")), normalized),
+                    cb.like(cb.lower(root.get("street1")), normalized),
+                    cb.like(cb.lower(root.get("street2")), normalized),
+                    cb.like(cb.lower(root.get("city")), normalized),
+                    cb.like(cb.lower(root.get("state")), normalized),
+                    cb.like(cb.lower(root.get("zip")), normalized)
+            );
+        };
+    }
     private static Specification<Property> eqStatus(PropertyStatus status) {
         return (root, query, cb) -> status == null ? cb.conjunction() : cb.equal(root.get("status"), status);
     }

--- a/frontend/src/pages/admin/AdminPropertiesPage.css
+++ b/frontend/src/pages/admin/AdminPropertiesPage.css
@@ -15,7 +15,7 @@
 
 .adminProps__filterRow {
   display: grid;
-  grid-template-columns: 2.2fr 1fr 1fr 0.9fr auto;
+  grid-template-columns: 2.2fr 1fr 1.4fr auto auto;
   gap: 10px;
   align-items: end;
 }
@@ -45,6 +45,51 @@
   color: var(--admin-ink);
   outline: none;
   font-family: inherit;
+}
+
+.adminProps__input--text {
+  background-image: none;
+  padding-right: 10px;
+}
+
+.adminProps__rangeInputs {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.adminProps__moreMenu {
+  position: relative;
+}
+
+.adminProps__moreSummary {
+  list-style: none;
+  height: 41px;
+  min-width: 88px;
+  border: 1px solid var(--admin-border);
+  padding: 0 12px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.adminProps__moreSummary::-webkit-details-marker {
+  display: none;
+}
+
+.adminProps__moreBody {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 8px);
+  z-index: 2;
+  width: min(360px, 82vw);
+  border: 1px solid var(--admin-border);
+  background: #fff;
+  padding: 12px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
 }
 
 .adminProps__input:focus {
@@ -92,6 +137,12 @@
 @media (max-width: 1100px) {
   .adminProps__filterRow {
     grid-template-columns: 1fr 1fr;
+  }
+
+  .adminProps__moreBody {
+    position: static;
+    margin-top: 8px;
+    width: 100%;
   }
 
   .adminProps__iconBtn {

--- a/frontend/src/pages/admin/AdminPropertiesPage.jsx
+++ b/frontend/src/pages/admin/AdminPropertiesPage.jsx
@@ -24,14 +24,6 @@ const EXIT_STRATEGIES = [
   { label: "Wholesale", value: "WHOLESALE" },
 ];
 
-const CLOSING_TERMS = [
-  { label: "All", value: "" },
-  { label: "Cash Only", value: "CASH_ONLY" },
-  { label: "Hard Money", value: "HARD_MONEY" },
-  { label: "Conventional", value: "CONVENTIONAL" },
-  { label: "Seller Finance", value: "SELLER_FINANCE" },
-];
-
 const STATUSES = [
   { label: "All", value: "" },
   { label: "Draft", value: "DRAFT" },
@@ -143,9 +135,13 @@ function Pagination({ page, totalPages, onPageChange }) {
 
 export default function AdminPropertiesPage() {
   const [filters, setFilters] = useState({
+    q: "",
+    minAskingPrice: "",
+    maxAskingPrice: "",
+    minBeds: "",
+    minBaths: "",
     occupancyStatus: "",
     exitStrategy: "",
-    closingTerms: "",
     status: "",
   });
 
@@ -389,48 +385,14 @@ export default function AdminPropertiesPage() {
       >
         <div className="adminProps__filterRow">
           <label className="adminProps__filter">
-            <span className="adminProps__label">Occupancy Status</span>
-            <select
-              className="adminProps__input"
-              value={filters.occupancyStatus}
-              onChange={(e) => updateFilter("occupancyStatus", e.target.value)}
-            >
-              {OCCUPANCY.map((o) => (
-                <option key={o.label} value={o.value}>
-                  {o.label}
-                </option>
-              ))}
-            </select>
-          </label>
-
-          <label className="adminProps__filter">
-            <span className="adminProps__label">Exit Strategy</span>
-            <select
-              className="adminProps__input"
-              value={filters.exitStrategy}
-              onChange={(e) => updateFilter("exitStrategy", e.target.value)}
-            >
-              {EXIT_STRATEGIES.map((o) => (
-                <option key={o.label} value={o.value}>
-                  {o.label}
-                </option>
-              ))}
-            </select>
-          </label>
-
-          <label className="adminProps__filter">
-            <span className="adminProps__label">Closing Terms</span>
-            <select
-              className="adminProps__input"
-              value={filters.closingTerms}
-              onChange={(e) => updateFilter("closingTerms", e.target.value)}
-            >
-              {CLOSING_TERMS.map((o) => (
-                <option key={o.label} value={o.value}>
-                  {o.label}
-                </option>
-              ))}
-            </select>
+            <span className="adminProps__label">Search</span>
+            <input
+              className="adminProps__input adminProps__input--text"
+              type="search"
+              placeholder="Address or title"
+              value={filters.q}
+              onChange={(e) => updateFilter("q", e.target.value)}
+            />
           </label>
 
           <label className="adminProps__filter">
@@ -447,6 +409,91 @@ export default function AdminPropertiesPage() {
               ))}
             </select>
           </label>
+
+          <label className="adminProps__filter">
+            <span className="adminProps__label">Asking Price</span>
+            <div className="adminProps__rangeInputs">
+              <input
+                className="adminProps__input adminProps__input--text"
+                type="text"
+                inputMode="numeric"
+                placeholder="Min"
+                value={filters.minAskingPrice}
+                onChange={(e) => updateFilter("minAskingPrice", e.target.value)}
+              />
+              <input
+                className="adminProps__input adminProps__input--text"
+                type="text"
+                inputMode="numeric"
+                placeholder="Max"
+                value={filters.maxAskingPrice}
+                onChange={(e) => updateFilter("maxAskingPrice", e.target.value)}
+              />
+            </div>
+          </label>
+
+          <details className="adminProps__moreMenu">
+            <summary className="adminProps__moreSummary">More</summary>
+
+            <div className="adminProps__moreBody">
+              <label className="adminProps__filter">
+                <span className="adminProps__label">Beds (Min)</span>
+                <input
+                  className="adminProps__input adminProps__input--text"
+                  type="number"
+                  min="0"
+                  placeholder="Any"
+                  value={filters.minBeds}
+                  onChange={(e) => updateFilter("minBeds", e.target.value)}
+                />
+              </label>
+
+              <label className="adminProps__filter">
+                <span className="adminProps__label">Baths (Min)</span>
+                <input
+                  className="adminProps__input adminProps__input--text"
+                  type="number"
+                  min="0"
+                  step="0.5"
+                  placeholder="Any"
+                  value={filters.minBaths}
+                  onChange={(e) => updateFilter("minBaths", e.target.value)}
+                />
+              </label>
+
+              <label className="adminProps__filter">
+                <span className="adminProps__label">Occupancy Status</span>
+                <select
+                  className="adminProps__input"
+                  value={filters.occupancyStatus}
+                  onChange={(e) =>
+                    updateFilter("occupancyStatus", e.target.value)
+                  }
+                >
+                  {OCCUPANCY.map((o) => (
+                    <option key={o.label} value={o.value}>
+                      {o.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              <label className="adminProps__filter">
+                <span className="adminProps__label">Exit Strategy</span>
+                <select
+                  className="adminProps__input"
+                  value={filters.exitStrategy}
+                  onChange={(e) => updateFilter("exitStrategy", e.target.value)}
+                >
+                  {EXIT_STRATEGIES.map((o) => (
+                    <option key={o.label} value={o.value}>
+                      {o.label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            </div>
+          </details>
 
           <button
             className="adminProps__iconBtn"


### PR DESCRIPTION
### Motivation
- Simplify the admin properties filter area to surface only the most-used controls (search, status, asking price range) while keeping less-used filters accessible under a single "More" menu.
- Enable text searching across title/address and support a minimum-baths filter on the backend so the new UI filters can be applied server-side.

### Description
- Frontend: replaced the crowded filter row in `AdminPropertiesPage.jsx` with a top-level `Search` input (`q`), `Status` select, and an `Asking Price` min/max pair, and added a `More` details menu containing `Beds (Min)`, `Baths (Min)`, `Occupancy Status`, and `Exit Strategy` controls; adjusted `filters` state to include `q`, `minAskingPrice`, `maxAskingPrice`, `minBeds`, and `minBaths`, and removed the previously visible closing terms control from the top row.
- Frontend: added CSS in `AdminPropertiesPage.css` for compact text inputs, range inputs, and the `More` dropdown panel with responsive behavior.
- Backend: added a `q` request param and `minBaths` param to the properties search endpoint in `PropertyController`, threaded `query` and `minBaths` through `PropertyService`, and extended `PropertySpecifications.withFilters` to accept the new args.
- Backend: implemented `matchesSearchTerm` in `PropertySpecifications` to match `q` against `title`, `street1`, `street2`, `city`, `state`, and `zip`, and added `gteDecimal("baths", minBaths)` so the minimum-baths filter is applied.

### Testing
- `cd frontend && npm run build` completed successfully and produced a production build. ✅
- `cd backend && ./mvnw test` could not complete in this environment because the Maven wrapper failed to download the Maven distribution, so backend unit tests were not executed here. ⚠️
- Started the frontend dev server and captured an automated screenshot of `/admin/properties` to verify the filters layout visually. ✅

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699946807a9c832ca608a821e541cbd9)