### PR TITLE
Admin Investors page with review modal, filters, and backend search/rejection updates

### DIFF
--- a/backend/src/main/java/com/megna/backend/controllers/InvestorController.java
+++ b/backend/src/main/java/com/megna/backend/controllers/InvestorController.java
@@ -12,8 +12,11 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
 
 @RestController
 @RequestMapping("/api/investors")
@@ -62,11 +65,15 @@ public class InvestorController {
     @GetMapping("/search")
     public Page<InvestorResponseDto> search(
             @RequestParam(required = false) InvestorStatus status,
-            @RequestParam(required = false) String email,
-            @RequestParam(required = false) String companyName,
-            @RequestParam(required = false) String name,
+            @RequestParam(required = false) String q,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime createdFrom,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime createdTo,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime updatedFrom,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime updatedTo,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime approvedFrom,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime approvedTo,
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
             ) {
-        return investorService.search(status, email, companyName, name, pageable);
+        return investorService.search(status, q, createdFrom, createdTo, updatedFrom, updatedTo, approvedFrom, approvedTo, pageable);
     }
 }

--- a/backend/src/main/java/com/megna/backend/controllers/admin/AdminInvestorApprovalController.java
+++ b/backend/src/main/java/com/megna/backend/controllers/admin/AdminInvestorApprovalController.java
@@ -11,8 +11,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
 
 @RestController
 @RequestMapping("/api/admin/investors")
@@ -26,7 +29,7 @@ public class AdminInvestorApprovalController {
     public Page<InvestorResponseDto> getPending(
             @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
             ) {
-        return investorService.search(InvestorStatus.PENDING, null, null, null, pageable);
+        return investorService.search(InvestorStatus.PENDING, null, null, null, null, null, null, null, pageable);
     }
 
     @PatchMapping("/{id}/approve")
@@ -44,17 +47,37 @@ public class AdminInvestorApprovalController {
         return investorService.getById(id);
     }
 
+    @GetMapping("/search")
+    public Page<InvestorResponseDto> search(
+            @RequestParam(required = false) InvestorStatus status,
+            @RequestParam(required = false) String q,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime createdFrom,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime createdTo,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime updatedFrom,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime updatedTo,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime approvedFrom,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime approvedTo,
+            @PageableDefault(size = 20, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return investorService.search(status, q, createdFrom, createdTo, updatedFrom, updatedTo, approvedFrom, approvedTo, pageable);
+    }
+
+    @PatchMapping("/{id}/rejection-reason")
+    public InvestorResponseDto updateRejectionReason(@PathVariable Long id, @Valid @RequestBody InvestorRejectionRequestDto dto) {
+        return investorService.updateRejectionReason(id, dto);
+    }
+
     @GetMapping("/approved")
     public Page<InvestorResponseDto> getApproved(
             @PageableDefault(size = 20, sort = "approvedAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        return investorService.search(InvestorStatus.APPROVED, null, null, null, pageable);
+        return investorService.search(InvestorStatus.APPROVED, null, null, null, null, null, null, null, pageable);
     }
 
     @GetMapping("/rejected")
     public Page<InvestorResponseDto> getRejected(
             @PageableDefault(size = 20, sort = "updatedAt", direction = Sort.Direction.DESC) Pageable pageable
     ) {
-        return investorService.search(InvestorStatus.REJECTED, null, null, null, pageable);
+        return investorService.search(InvestorStatus.REJECTED, null, null, null, null, null, null, null, pageable);
     }
 }

--- a/backend/src/main/java/com/megna/backend/services/InvestorService.java
+++ b/backend/src/main/java/com/megna/backend/services/InvestorService.java
@@ -18,6 +18,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.time.LocalDateTime;
+
 @Service
 @RequiredArgsConstructor
 public class InvestorService {
@@ -135,17 +137,49 @@ public class InvestorService {
 
     public Page<InvestorResponseDto> search(
             InvestorStatus status,
-            String email,
-            String companyName,
-            String name,
+            String q,
+            LocalDateTime createdFrom,
+            LocalDateTime createdTo,
+            LocalDateTime updatedFrom,
+            LocalDateTime updatedTo,
+            LocalDateTime approvedFrom,
+            LocalDateTime approvedTo,
             Pageable pageable
     ) {
         requireAdmin();
 
-        var spec = InvestorSpecifications.withFilters(status, email, companyName, name);
+        var spec = InvestorSpecifications.withFilters(
+                status,
+                q,
+                createdFrom,
+                createdTo,
+                updatedFrom,
+                updatedTo,
+                approvedFrom,
+                approvedTo
+        );
 
         return investorRepository.findAll(spec, pageable)
                 .map(InvestorMapper::toDto);
+    }
+
+    public InvestorResponseDto updateRejectionReason(Long id, InvestorRejectionRequestDto dto) {
+        requireAdmin();
+
+        Investor investor = investorRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Investor not found: " + id));
+
+        if (investor.getStatus() != InvestorStatus.REJECTED) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "Can only update rejection reason for REJECTED investors"
+            );
+        }
+
+        investor.setRejectionReason(dto.rejectionReason().trim());
+
+        Investor saved = investorRepository.save(investor);
+        return InvestorMapper.toDto(saved);
     }
 
     private AuthPrincipal principal() {

--- a/backend/src/main/java/com/megna/backend/specifications/InvestorSpecifications.java
+++ b/backend/src/main/java/com/megna/backend/specifications/InvestorSpecifications.java
@@ -4,20 +4,27 @@ import com.megna.backend.entities.Investor;
 import com.megna.backend.enums.InvestorStatus;
 import org.springframework.data.jpa.domain.Specification;
 
+import java.time.LocalDateTime;
+
 public final class InvestorSpecifications {
 
     private InvestorSpecifications() {}
 
     public static Specification<Investor> withFilters(
             InvestorStatus status,
-            String email,
-            String companyName,
-            String name
+            String q,
+            LocalDateTime createdFrom,
+            LocalDateTime createdTo,
+            LocalDateTime updatedFrom,
+            LocalDateTime updatedTo,
+            LocalDateTime approvedFrom,
+            LocalDateTime approvedTo
     ) {
         return Specification.where(eqStatus(status))
-                .and(containsIgnoreCase("email", email))
-                .and(containsIgnoreCase("companyName", companyName))
-                .and(nameContainsIgnoreCase(name));
+                .and(matchesQuery(q))
+                .and(dateBetween("createdAt", createdFrom, createdTo))
+                .and(dateBetween("updatedAt", updatedFrom, updatedTo))
+                .and(dateBetween("approvedAt", approvedFrom, approvedTo));
     }
 
     private static Specification<Investor> eqStatus(InvestorStatus status) {
@@ -31,14 +38,26 @@ public final class InvestorSpecifications {
         };
     }
 
-    private static Specification<Investor> nameContainsIgnoreCase(String name) {
+    private static Specification<Investor> matchesQuery(String q) {
         return (root, query, cb) -> {
-            if (name == null || name.isBlank()) return cb.conjunction();
-            String like = "%" + name.toLowerCase() + "%";
+            if (q == null || q.isBlank()) return cb.conjunction();
+            String like = "%" + q.toLowerCase() + "%";
             return cb.or(
                     cb.like(cb.lower(root.get("firstName")), like),
-                    cb.like(cb.lower(root.get("lastName")), like)
+                    cb.like(cb.lower(root.get("lastName")), like),
+                    containsIgnoreCase("companyName", q).toPredicate(root, query, cb),
+                    containsIgnoreCase("email", q).toPredicate(root, query, cb),
+                    containsIgnoreCase("phone", q).toPredicate(root, query, cb)
             );
+        };
+    }
+
+    private static Specification<Investor> dateBetween(String field, LocalDateTime from, LocalDateTime to) {
+        return (root, query, cb) -> {
+            if (from == null && to == null) return cb.conjunction();
+            if (from != null && to != null) return cb.between(root.get(field), from, to);
+            if (from != null) return cb.greaterThanOrEqualTo(root.get(field), from);
+            return cb.lessThanOrEqualTo(root.get(field), to);
         };
     }
 }

--- a/frontend/src/api/adminInvestorApi.js
+++ b/frontend/src/api/adminInvestorApi.js
@@ -3,36 +3,54 @@ import { buildPageParams } from "./params";
 
 const BASE = "/api/admin/investors";
 
-export async function getPendingInvestors(pageOpts = {}) {
-    const params = buildPageParams(pageOpts);
-    const { data } = await apiClient.get(`${BASE}/pending`, { params });
-    return data;
-}
+export async function searchAdminInvestors(filters = {}, pageOpts = {}) {
+  const params = {
+    ...buildPageParams(pageOpts),
+    ...(filters?.q ? { q: filters.q } : {}),
+    ...(filters?.status ? { status: filters.status } : {}),
+    ...(filters?.createdFrom ? { createdFrom: filters.createdFrom } : {}),
+    ...(filters?.createdTo ? { createdTo: filters.createdTo } : {}),
+    ...(filters?.updatedFrom ? { updatedFrom: filters.updatedFrom } : {}),
+    ...(filters?.updatedTo ? { updatedTo: filters.updatedTo } : {}),
+    ...(filters?.approvedFrom ? { approvedFrom: filters.approvedFrom } : {}),
+    ...(filters?.approvedTo ? { approvedTo: filters.approvedTo } : {}),
+  };
 
-export async function getApprovedInvestors(pageOpts = {}) {
-    const params = buildPageParams(pageOpts);
-    const { data } = await apiClient.get(`${BASE}/approved`, { params });
-    return data;
-}
-
-export async function getRejectedInvestors(pageOpts = {}) {
-    const params = buildPageParams(pageOpts);
-    const { data } = await apiClient.get(`${BASE}/rejected`, { params });
-    return data;
+  const { data } = await apiClient.get(`${BASE}/search`, { params });
+  return data;
 }
 
 export async function getAdminInvestorById(id) {
-    const { data } = await apiClient.get(`${BASE}/${id}`);
-    return data;
+  const { data } = await apiClient.get(`${BASE}/${id}`);
+  return data;
 }
 
 export async function approveInvestor(id) {
-    const { data } = await apiClient.patch(`${BASE}/${id}/approve`, null);
-    return data;
+  const { data } = await apiClient.patch(`${BASE}/${id}/approve`, null);
+  return data;
 }
 
 export async function rejectInvestor(id, rejectionReason) {
-    const body = { rejectionReason };
-    const { data } = await apiClient.patch(`${BASE}/${id}/reject`, body);
-    return data;
+  const body = { rejectionReason };
+  const { data } = await apiClient.patch(`${BASE}/${id}/reject`, body);
+  return data;
+}
+
+export async function updateInvestorRejectionReason(id, rejectionReason) {
+  const body = { rejectionReason };
+  const { data } = await apiClient.patch(`${BASE}/${id}/rejection-reason`, body);
+  return data;
+}
+
+
+export async function getPendingInvestors(pageOpts = {}) {
+  return searchAdminInvestors({ status: "PENDING" }, pageOpts);
+}
+
+export async function getApprovedInvestors(pageOpts = {}) {
+  return searchAdminInvestors({ status: "APPROVED" }, pageOpts);
+}
+
+export async function getRejectedInvestors(pageOpts = {}) {
+  return searchAdminInvestors({ status: "REJECTED" }, pageOpts);
 }

--- a/frontend/src/modals/AdminInvestorReviewModal.css
+++ b/frontend/src/modals/AdminInvestorReviewModal.css
@@ -1,0 +1,97 @@
+.invModal {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  color: #f2f2f2;
+}
+
+.invModal__grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  font-size: 13px;
+}
+
+.invModal__grid span {
+  color: rgba(242, 242, 242, 0.7);
+}
+
+.invModal__statusSection {
+  border-top: 1px solid rgba(242, 242, 242, 0.18);
+  padding-top: 12px;
+}
+
+.invModal__label {
+  font-size: 12px;
+  color: rgba(242, 242, 242, 0.7);
+  margin-bottom: 8px;
+}
+
+.invModal__statuses {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.invModal__statusBtn {
+  border: 1px solid rgba(242, 242, 242, 0.24);
+  background: transparent;
+  color: #f2f2f2;
+  padding: 10px 12px;
+  cursor: pointer;
+}
+
+.invModal__statusBtn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.invModal__statusBtn--danger.invModal__statusBtn--active {
+  background: #7f1d1d;
+  border-color: #7f1d1d;
+}
+
+.invModal__statusBtn--success.invModal__statusBtn--active {
+  background: #14532d;
+  border-color: #14532d;
+}
+
+.invModal__reasonWrap {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 10px;
+  font-size: 12px;
+  color: rgba(242, 242, 242, 0.7);
+}
+
+.invModal__reasonWrap textarea {
+  border: 1px solid rgba(242, 242, 242, 0.24);
+  background: transparent;
+  color: #f2f2f2;
+  padding: 10px;
+  font-family: inherit;
+}
+
+.invModal__actions {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+.invModal__btn {
+  border: 1px solid rgba(242, 242, 242, 0.6);
+  background: transparent;
+  color: #f2f2f2;
+  padding: 10px 12px;
+  cursor: pointer;
+}
+
+.invModal__btn--primary {
+  border-color: #f2f2f2;
+}
+
+.invModal__error {
+  color: #fca5a5;
+  font-size: 12px;
+}

--- a/frontend/src/modals/AdminInvestorReviewModal.jsx
+++ b/frontend/src/modals/AdminInvestorReviewModal.jsx
@@ -1,0 +1,125 @@
+import { useEffect, useMemo, useState } from "react";
+import Modal from "../components/Modal";
+import "./AdminInvestorReviewModal.css";
+
+function fmtDate(value) {
+  if (!value) return "—";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+  });
+}
+
+export default function AdminInvestorReviewModal({
+  open,
+  investor,
+  submitting = false,
+  submitError = "",
+  onClose,
+  onSave,
+}) {
+  const status = investor?.status ?? "";
+  const isPending = status === "PENDING";
+  const isApproved = status === "APPROVED";
+  const isRejected = status === "REJECTED";
+
+  const [nextStatus, setNextStatus] = useState("APPROVED");
+  const [rejectionReason, setRejectionReason] = useState("");
+
+  useEffect(() => {
+    if (!open || !investor) return;
+    setNextStatus(isPending ? "APPROVED" : status);
+    setRejectionReason(investor.rejectionReason ?? "");
+  }, [open, investor, status, isPending]);
+
+  const isReadOnly = isApproved;
+  const requiresReason = useMemo(
+    () => (isPending && nextStatus === "REJECTED") || isRejected,
+    [isPending, nextStatus, isRejected],
+  );
+
+  function handleSave() {
+    if (isReadOnly) return;
+    onSave?.({ status: nextStatus, rejectionReason });
+  }
+
+  return (
+    <Modal
+      open={open}
+      title={isPending ? "Review Investor" : "Investor Details"}
+      onClose={onClose}
+      width={760}
+    >
+      {!investor ? null : (
+        <div className="invModal">
+          <div className="invModal__grid">
+            <div><span>Name:</span> {investor.firstName} {investor.lastName}</div>
+            <div><span>Company:</span> {investor.companyName || "—"}</div>
+            <div><span>Email:</span> {investor.email}</div>
+            <div><span>Phone:</span> {investor.phone || "—"}</div>
+            <div><span>Status:</span> {investor.status}</div>
+            <div><span>Created:</span> {fmtDate(investor.createdAt)}</div>
+            <div><span>Updated:</span> {fmtDate(investor.updatedAt)}</div>
+            <div><span>Approved:</span> {fmtDate(investor.approvedAt)}</div>
+          </div>
+
+          <div className="invModal__statusSection">
+            <div className="invModal__label">Status Action</div>
+            <div className="invModal__statuses">
+              <button
+                type="button"
+                disabled={!isPending || submitting}
+                className={`invModal__statusBtn ${nextStatus === "REJECTED" ? "invModal__statusBtn--danger invModal__statusBtn--active" : "invModal__statusBtn--danger"}`}
+                onClick={() => setNextStatus("REJECTED")}
+              >
+                Reject
+              </button>
+              <button
+                type="button"
+                disabled={!isPending || submitting}
+                className={`invModal__statusBtn ${nextStatus === "APPROVED" ? "invModal__statusBtn--success invModal__statusBtn--active" : "invModal__statusBtn--success"}`}
+                onClick={() => setNextStatus("APPROVED")}
+              >
+                Approve
+              </button>
+            </div>
+
+            {requiresReason ? (
+              <label className="invModal__reasonWrap">
+                <span>Rejection Reason</span>
+                <textarea
+                  value={rejectionReason}
+                  disabled={(isPending && nextStatus !== "REJECTED") || isApproved || submitting}
+                  onChange={(e) => setRejectionReason(e.target.value)}
+                  rows={3}
+                  maxLength={500}
+                />
+              </label>
+            ) : null}
+          </div>
+
+          {submitError ? <div className="invModal__error">{submitError}</div> : null}
+
+          <div className="invModal__actions">
+            <button type="button" className="invModal__btn" onClick={onClose} disabled={submitting}>
+              Cancel
+            </button>
+            <button
+              type="button"
+              className="invModal__btn invModal__btn--primary"
+              onClick={handleSave}
+              disabled={submitting || isReadOnly || (requiresReason && !rejectionReason.trim())}
+            >
+              {submitting ? "Saving..." : "Save"}
+            </button>
+          </div>
+        </div>
+      )}
+    </Modal>
+  );
+}

--- a/frontend/src/pages/admin/AdminInvestorPage.jsx
+++ b/frontend/src/pages/admin/AdminInvestorPage.jsx
@@ -1,3 +1,263 @@
+import { useEffect, useMemo, useState } from "react";
+import {
+  approveInvestor,
+  getAdminInvestorById,
+  rejectInvestor,
+  searchAdminInvestors,
+  updateInvestorRejectionReason,
+} from "../../api/adminInvestorApi";
+import AdminInvestorReviewModal from "../../modals/AdminInvestorReviewModal";
+import "./AdminInvestorsPage.css";
+
+const PAGE_SIZE = 20;
+
+const STATUS_OPTIONS = [
+  { label: "All", value: "" },
+  { label: "Pending", value: "PENDING" },
+  { label: "Approved", value: "APPROVED" },
+  { label: "Rejected", value: "REJECTED" },
+];
+
+const RANGE_OPTIONS = [
+  { label: "Any time", value: "" },
+  { label: "Last 7 days", value: "7" },
+  { label: "Last 30 days", value: "30" },
+  { label: "Last 90 days", value: "90" },
+];
+
+function toRange(days) {
+  if (!days) return { from: null, to: null };
+  const now = new Date();
+  const from = new Date(now);
+  from.setDate(from.getDate() - Number(days));
+  return { from: from.toISOString(), to: now.toISOString() };
+}
+
+function prettyDate(value) {
+  if (!value) return "—";
+  const d = new Date(value);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toLocaleString("en-US", { month: "short", day: "2-digit", year: "numeric" });
+}
+
+function Pagination({ page, totalPages, onPageChange }) {
+  if (!totalPages || totalPages <= 1) return null;
+  return (
+    <div className="adminInv__pagination">
+      <button className="adminInv__pageBtn" type="button" disabled={page === 0} onClick={() => onPageChange(page - 1)}>Prev</button>
+      <span className="adminInv__pageMeta">Page {page + 1} / {totalPages}</span>
+      <button className="adminInv__pageBtn" type="button" disabled={page >= totalPages - 1} onClick={() => onPageChange(page + 1)}>Next</button>
+    </div>
+  );
+}
+
 export default function AdminInvestorsPage() {
-  return <h2>Admin • Investors</h2>;
+  const [filters, setFilters] = useState({
+    q: "",
+    status: "",
+    createdRange: "",
+    updatedRange: "",
+    approvedRange: "",
+  });
+  const [page, setPage] = useState(0);
+  const [rows, setRows] = useState([]);
+  const [meta, setMeta] = useState({ totalPages: 0, totalElements: 0 });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  const [selectedInvestor, setSelectedInvestor] = useState(null);
+  const [modalOpen, setModalOpen] = useState(false);
+  const [submitError, setSubmitError] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  const hasMoreFiltersSelected = useMemo(() => {
+    return [filters.createdRange, filters.updatedRange, filters.approvedRange].some(Boolean);
+  }, [filters.createdRange, filters.updatedRange, filters.approvedRange]);
+
+  useEffect(() => {
+    let alive = true;
+    async function load() {
+      setLoading(true);
+      setError("");
+      try {
+        const created = toRange(filters.createdRange);
+        const updated = toRange(filters.updatedRange);
+        const approved = filters.status === "APPROVED" ? toRange(filters.approvedRange) : { from: null, to: null };
+
+        const data = await searchAdminInvestors(
+          {
+            q: filters.q.trim(),
+            status: filters.status,
+            createdFrom: created.from,
+            createdTo: created.to,
+            updatedFrom: updated.from,
+            updatedTo: updated.to,
+            approvedFrom: approved.from,
+            approvedTo: approved.to,
+          },
+          { page, size: PAGE_SIZE },
+        );
+
+        if (!alive) return;
+        setRows(data?.content ?? []);
+        setMeta({ totalPages: data?.totalPages ?? 0, totalElements: data?.totalElements ?? 0 });
+      } catch (e) {
+        if (!alive) return;
+        setRows([]);
+        setMeta({ totalPages: 0, totalElements: 0 });
+        setError(e?.message || "Failed to load investors.");
+      } finally {
+        if (alive) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      alive = false;
+    };
+  }, [filters, page]);
+
+  function updateFilter(key, value) {
+    setFilters((prev) => ({ ...prev, [key]: value }));
+    setPage(0);
+  }
+
+  async function openModal(id) {
+    setSubmitError("");
+    const full = await getAdminInvestorById(id);
+    setSelectedInvestor(full);
+    setModalOpen(true);
+  }
+
+  async function handleSave({ status, rejectionReason }) {
+    if (!selectedInvestor) return;
+    setSubmitting(true);
+    setSubmitError("");
+    try {
+      if (selectedInvestor.status === "PENDING") {
+        if (status === "APPROVED") await approveInvestor(selectedInvestor.id);
+        if (status === "REJECTED") await rejectInvestor(selectedInvestor.id, rejectionReason.trim());
+      } else if (selectedInvestor.status === "REJECTED") {
+        await updateInvestorRejectionReason(selectedInvestor.id, rejectionReason.trim());
+      }
+      setModalOpen(false);
+      setSelectedInvestor(null);
+      updateFilter("q", filters.q);
+    } catch (e) {
+      setSubmitError(e?.message || "Failed to save investor.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <section className="adminInv">
+      <form className="adminInv__filters" onSubmit={(e) => e.preventDefault()}>
+        <div className="adminInv__filterRow">
+          <label className="adminInv__filter">
+            <span className="adminInv__label">Search</span>
+            <input className="adminInv__input adminInv__input--text" type="search" placeholder="Name, company, email, phone" value={filters.q} onChange={(e) => updateFilter("q", e.target.value)} />
+          </label>
+
+          <label className="adminInv__filter">
+            <span className="adminInv__label">Status</span>
+            <select className="adminInv__input" value={filters.status} onChange={(e) => updateFilter("status", e.target.value)}>
+              {STATUS_OPTIONS.map((option) => (
+                <option key={option.label} value={option.value}>{option.label}</option>
+              ))}
+            </select>
+          </label>
+
+          <details className="adminInv__moreMenu">
+            <summary className={`adminInv__moreSummary ${hasMoreFiltersSelected ? "adminInv__moreSummary--active" : ""}`}>More</summary>
+            <div className="adminInv__moreBody">
+              <label className="adminInv__filter">
+                <span className="adminInv__label">Created</span>
+                <select className="adminInv__input" value={filters.createdRange} onChange={(e) => updateFilter("createdRange", e.target.value)}>
+                  {RANGE_OPTIONS.map((option) => <option key={option.label} value={option.value}>{option.label}</option>)}
+                </select>
+              </label>
+
+              <label className="adminInv__filter">
+                <span className="adminInv__label">Updated</span>
+                <select className="adminInv__input" value={filters.updatedRange} onChange={(e) => updateFilter("updatedRange", e.target.value)}>
+                  {RANGE_OPTIONS.map((option) => <option key={option.label} value={option.value}>{option.label}</option>)}
+                </select>
+              </label>
+
+              {filters.status === "APPROVED" ? (
+                <label className="adminInv__filter">
+                  <span className="adminInv__label">Approved</span>
+                  <select className="adminInv__input" value={filters.approvedRange} onChange={(e) => updateFilter("approvedRange", e.target.value)}>
+                    {RANGE_OPTIONS.map((option) => <option key={option.label} value={option.value}>{option.label}</option>)}
+                  </select>
+                </label>
+              ) : null}
+            </div>
+          </details>
+        </div>
+      </form>
+
+      <div className="adminInv__tableSection">
+        {loading ? <div className="adminInv__notice">Loading investors...</div> : null}
+        {!loading && error ? <div className="adminInv__notice adminInv__notice--error">{error}</div> : null}
+        {!loading && !error && rows.length === 0 ? <div className="adminInv__notice">No investors found.</div> : null}
+
+        {!loading && rows.length > 0 ? (
+          <>
+            <div className="adminInv__tableWrap">
+              <table className="adminInv__table">
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Company</th>
+                    <th>Email</th>
+                    <th>Phone</th>
+                    <th>Status</th>
+                    {filters.status === "REJECTED" ? <th>Rejection Reason</th> : null}
+                    <th>Created</th>
+                    <th>Updated</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {rows.map((investor) => (
+                    <tr key={investor.id}>
+                      <td>{investor.firstName} {investor.lastName}</td>
+                      <td>{investor.companyName || "—"}</td>
+                      <td>{investor.email || "—"}</td>
+                      <td>{investor.phone || "—"}</td>
+                      <td>{investor.status}</td>
+                      {filters.status === "REJECTED" ? <td>{investor.rejectionReason || "—"}</td> : null}
+                      <td>{prettyDate(investor.createdAt)}</td>
+                      <td>{prettyDate(investor.updatedAt)}</td>
+                      <td>
+                        <button type="button" className="adminInv__actionBtn" onClick={() => openModal(investor.id)}>
+                          {investor.status === "PENDING" ? "Review" : "View"}
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+            <Pagination page={page} totalPages={meta.totalPages} onPageChange={setPage} />
+          </>
+        ) : null}
+      </div>
+
+      <AdminInvestorReviewModal
+        open={modalOpen}
+        investor={selectedInvestor}
+        submitting={submitting}
+        submitError={submitError}
+        onClose={() => {
+          if (!submitting) {
+            setModalOpen(false);
+            setSelectedInvestor(null);
+          }
+        }}
+        onSave={handleSave}
+      />
+    </section>
+  );
 }

--- a/frontend/src/pages/admin/AdminInvestorsPage.css
+++ b/frontend/src/pages/admin/AdminInvestorsPage.css
@@ -1,0 +1,55 @@
+.adminInv {
+  --admin-bg: #f2f2f2;
+  --admin-ink: #101010;
+  --admin-muted: rgba(16, 16, 16, 0.65);
+  --admin-border: rgba(16, 16, 16, 0.28);
+  color: var(--admin-ink);
+}
+
+.adminInv__filters,
+.adminInv__tableSection {
+  border: 1px solid var(--admin-border);
+  background: rgba(255, 255, 255, 0.55);
+  padding: 12px;
+}
+
+.adminInv__tableSection { margin-top: 14px; }
+
+.adminInv__filterRow { display: grid; grid-template-columns: 2fr 1fr auto; gap: 10px; align-items: end; }
+.adminInv__filter { display: flex; flex-direction: column; gap: 6px; }
+.adminInv__label { font-size: 12px; color: var(--admin-muted); }
+
+.adminInv__input {
+  border: 1px solid var(--admin-border);
+  padding: 10px 34px 10px 10px;
+  background: transparent;
+  color: var(--admin-ink);
+  appearance: none;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='%23101010' stroke-width='1.8' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9' /%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-size: 16px;
+  background-position: right 12px center;
+}
+.adminInv__input--text { background-image: none; padding-right: 10px; }
+
+.adminInv__moreSummary { list-style: none; height: 41px; min-width: 88px; border: 1px solid var(--admin-border); display:grid; place-items:center; cursor:pointer; }
+.adminInv__moreSummary::-webkit-details-marker { display:none; }
+.adminInv__moreSummary--active, .adminInv__moreMenu[open] .adminInv__moreSummary { background: var(--admin-ink); color: var(--admin-bg); }
+.adminInv__moreMenu { position:relative; }
+.adminInv__moreBody { position:absolute; right:0; top:calc(100% + 8px); width:min(360px, 82vw); background:#fff; border:1px solid var(--admin-border); padding:12px; display:grid; gap:10px; z-index:2; }
+
+.adminInv__tableWrap { overflow:auto; }
+.adminInv__table { width:100%; border-collapse: collapse; font-size:13px; }
+.adminInv__table th,.adminInv__table td { padding: 10px; border-bottom: 1px solid rgba(16,16,16,0.12); text-align:left; white-space:nowrap; }
+.adminInv__table th { font-size:12px; color: var(--admin-muted); font-weight:400; }
+
+.adminInv__actionBtn, .adminInv__pageBtn { border:1px solid var(--admin-ink); background:transparent; color:var(--admin-ink); padding:7px 10px; cursor:pointer; }
+.adminInv__pagination { display:flex; justify-content:flex-end; align-items:center; gap:10px; padding-top:12px; }
+.adminInv__pageMeta { font-size:12px; color: var(--admin-muted); }
+.adminInv__notice { padding: 12px; color: var(--admin-muted); }
+.adminInv__notice--error { color: rgba(170, 38, 38, 0.95); }
+
+@media (max-width: 1000px) {
+  .adminInv__filterRow { grid-template-columns: 1fr; }
+  .adminInv__moreBody { position: static; width: 100%; }
+}


### PR DESCRIPTION
### Motivation
- Provide an admin UI for managing investor signups mirroring the `AdminPropertiesPage` UX, including search, status filters, date-range filters and a per-row review/view workflow.
- Allow admins to approve/reject pending investors and enable editing of rejection reasons for already-`REJECTED` investors.
- Expose server-side search by free-text across multiple investor fields and by created/updated/approved date ranges to back the UI filters.

### Description
- Frontend: implemented `AdminInvestorsPage` at `frontend/src/pages/admin/AdminInvestorPage.jsx` with search (matches `firstName`, `lastName`, `companyName`, `email`, `phone`), `Status` dropdown, and a `More` menu with `Created`/`Updated` ranges and `Approved` range (shown only when `APPROVED` is selected); table columns include `Name`, `Company`, `Email`, `Phone`, `Status`, `Created`, `Updated`, and conditionally `Rejection Reason` when `REJECTED` filter is active, and per-row `Review`/`View` action buttons. (`frontend/src/pages/admin/AdminInvestorsPage.css` adds styling.)
- Frontend: added `AdminInvestorReviewModal` (`frontend/src/modals/AdminInvestorReviewModal.jsx` + CSS) which shows investor details and provides Approve/Reject buttons (Reject requires a rejection reason) for `PENDING`, is view-only for `APPROVED`, and allows editing/saving the rejection reason for `REJECTED` investors.
- Frontend API: replaced/extended `frontend/src/api/adminInvestorApi.js` with `searchAdminInvestors` supporting `q`, `createdFrom/To`, `updatedFrom/To`, `approvedFrom/To` params and added `updateInvestorRejectionReason` plus compatibility helpers `getPendingInvestors`/`getApprovedInvestors`/`getRejectedInvestors`.
- Backend: extended search and update flows: updated `InvestorSpecifications` to support multi-field free-text (`firstName`, `lastName`, `companyName`, `email`, `phone`) and date-range filters (`createdAt`, `updatedAt`, `approvedAt`); updated `InvestorService.search(...)` signature and implementation to accept the new params; added `updateRejectionReason` service method to allow editing the rejection reason for `REJECTED` investors with proper authorization and validation; added controller endpoints and updated signatures in `AdminInvestorApprovalController` and `InvestorController` to accept the new search parameters and a `PATCH /api/admin/investors/{id}/rejection-reason` endpoint.
- Small utilities / UX: date-range selects map to ISO datetimes sent to backend; modal follows existing `PropertyUpsertModal` action pattern (Cancel/Save) with danger/green styling for reject/approve actions.

### Testing
- Frontend production build: ran `cd frontend && npm run build` which completed successfully (Vite build passed).
- Frontend dev smoke-run: started the dev server with `cd frontend && npm run dev -- --host 0.0.0.0 --port 4173` and captured a screenshot of `/admin/investors` using a Playwright script to validate layout (artifact saved).
- Backend compile attempt: `cd backend && ./mvnw -q -DskipTests compile` failed in this environment because the Maven wrapper could not download the Maven distribution from `repo.maven.apache.org`, so backend compilation could not be fully validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d0fc6ca10832c982794c100d30bb9)