### PR TITLE
Polish admin investor review modal interactions and styling

### DIFF
--- a/frontend/src/components/Modal.css
+++ b/frontend/src/components/Modal.css
@@ -2,7 +2,7 @@
     position: fixed;
     inset: 0;
     background: rgba(0, 0, 0, 0.55);
-    backdrop-filter: blue(8px);
+    backdrop-filter: blur(8px);
     display: grid;
     place-items: center;
     z-index: 999;
@@ -10,7 +10,7 @@
 }
 
 .mv-modal {
-    border: 1px solid var(--border-muted);
+    border: 1px solid var(--border-muted, rgba(242, 242, 242, 0.28));
     background: rgba(16, 16, 16, 0.96);
     box-shadow: 0 20px 80px rgba(0, 0, 0, 0.55);
     max-width: 92vw;
@@ -29,15 +29,21 @@
 .mv-modal__title {
     margin: 0;
     font-size: 16px;
+    color: var(--text, #f2f2f2);
 }
 
-mv-modal__x {
+.mv-modal__x {
     margin-left: auto;
-    border: 1px solid var(--border-muted);
+    border: 1px solid var(--border-muted, rgba(242, 242, 242, 0.28));
     background: transparent;
-    color: var(--text);
+    color: var(--text, #f2f2f2);
     padding: 6px 10px;
     cursor: pointer;
+}
+
+.mv-modal__x:hover {
+    background: var(--text, #f2f2f2);
+    color: #101010;
 }
 
 .mv-modal__body {

--- a/frontend/src/modals/AdminInvestorReviewModal.css
+++ b/frontend/src/modals/AdminInvestorReviewModal.css
@@ -1,8 +1,13 @@
 .invModal {
+  --text: #f2f2f2;
+  --muted: rgba(242, 242, 242, 0.7);
+  --border-muted: rgba(242, 242, 242, 0.24);
+  --bg: #101010;
+
   display: flex;
   flex-direction: column;
   gap: 14px;
-  color: #f2f2f2;
+  color: var(--text);
 }
 
 .invModal__grid {
@@ -13,7 +18,7 @@
 }
 
 .invModal__grid span {
-  color: rgba(242, 242, 242, 0.7);
+  color: var(--muted);
 }
 
 .invModal__statusSection {
@@ -23,7 +28,7 @@
 
 .invModal__label {
   font-size: 12px;
-  color: rgba(242, 242, 242, 0.7);
+  color: var(--muted);
   margin-bottom: 8px;
 }
 
@@ -34,11 +39,15 @@
 }
 
 .invModal__statusBtn {
-  border: 1px solid rgba(242, 242, 242, 0.24);
+  border: 1px solid var(--border-muted);
   background: transparent;
-  color: #f2f2f2;
+  color: var(--text);
   padding: 10px 12px;
   cursor: pointer;
+  transition:
+    background 180ms ease,
+    color 180ms ease,
+    border-color 180ms ease;
 }
 
 .invModal__statusBtn:disabled {
@@ -46,14 +55,46 @@
   cursor: not-allowed;
 }
 
+.invModal__statusBtn--danger {
+  color: #fca5a5;
+  border-color: #7f1d1d;
+}
+
+.invModal__statusBtn--danger:hover {
+  background: #7f1d1d;
+  color: #f2f2f2;
+}
+
 .invModal__statusBtn--danger.invModal__statusBtn--active {
   background: #7f1d1d;
-  border-color: #7f1d1d;
+  border-color: #fca5a5;
+  color: #f2f2f2;
+}
+
+.invModal__statusBtn--danger.invModal__statusBtn--active:hover {
+  background: transparent;
+  color: #fca5a5;
+}
+
+.invModal__statusBtn--success {
+  color: #86efac;
+  border-color: #14532d;
+}
+
+.invModal__statusBtn--success:hover {
+  background: #14532d;
+  color: #f2f2f2;
 }
 
 .invModal__statusBtn--success.invModal__statusBtn--active {
   background: #14532d;
-  border-color: #14532d;
+  border-color: #86efac;
+  color: #f2f2f2;
+}
+
+.invModal__statusBtn--success.invModal__statusBtn--active:hover {
+  background: transparent;
+  color: #86efac;
 }
 
 .invModal__reasonWrap {
@@ -62,15 +103,20 @@
   gap: 6px;
   margin-top: 10px;
   font-size: 12px;
-  color: rgba(242, 242, 242, 0.7);
+  color: var(--muted);
 }
 
 .invModal__reasonWrap textarea {
-  border: 1px solid rgba(242, 242, 242, 0.24);
+  border: 1px solid var(--border-muted);
   background: transparent;
-  color: #f2f2f2;
+  color: var(--text);
   padding: 10px;
   font-family: inherit;
+}
+
+.invModal__reasonWrap textarea:focus {
+  outline: none;
+  border-color: var(--text);
 }
 
 .invModal__actions {
@@ -80,18 +126,29 @@
 }
 
 .invModal__btn {
-  border: 1px solid rgba(242, 242, 242, 0.6);
+  border: 1px solid var(--text);
   background: transparent;
-  color: #f2f2f2;
-  padding: 10px 12px;
+  color: var(--text);
+  padding: 12px 14px;
   cursor: pointer;
+  transition:
+    background 180ms ease,
+    color 180ms ease,
+    border-color 180ms ease;
 }
 
-.invModal__btn--primary {
-  border-color: #f2f2f2;
+.invModal__btn:hover {
+  background: var(--text);
+  color: var(--bg);
+}
+
+.invModal__btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
 }
 
 .invModal__error {
   color: #fca5a5;
   font-size: 12px;
 }
+

--- a/frontend/src/modals/AdminInvestorReviewModal.jsx
+++ b/frontend/src/modals/AdminInvestorReviewModal.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import Modal from "../components/Modal";
 import "./AdminInvestorReviewModal.css";
 
@@ -15,6 +15,93 @@ function fmtDate(value) {
   });
 }
 
+function ReviewBody({ investor, submitting, submitError, onClose, onSave }) {
+  const status = investor?.status ?? "";
+  const isPending = status === "PENDING";
+  const isApproved = status === "APPROVED";
+  const isRejected = status === "REJECTED";
+
+  const [nextStatus, setNextStatus] = useState(isPending ? "" : status);
+  const [rejectionReason, setRejectionReason] = useState(investor.rejectionReason ?? "");
+
+  const isReadOnly = isApproved;
+  const requiresReason = useMemo(
+    () => (isPending && nextStatus === "REJECTED") || isRejected,
+    [isPending, nextStatus, isRejected],
+  );
+
+  function handleSave() {
+    if (isReadOnly || (isPending && !nextStatus)) return;
+    onSave?.({ status: nextStatus, rejectionReason });
+  }
+
+  return (
+    <div className="invModal">
+      <div className="invModal__grid">
+        <div><span>Name:</span> {investor.firstName} {investor.lastName}</div>
+        <div><span>Company:</span> {investor.companyName || "—"}</div>
+        <div><span>Email:</span> {investor.email}</div>
+        <div><span>Phone:</span> {investor.phone || "—"}</div>
+        <div><span>Status:</span> {investor.status}</div>
+        <div><span>Created:</span> {fmtDate(investor.createdAt)}</div>
+        <div><span>Updated:</span> {fmtDate(investor.updatedAt)}</div>
+        <div><span>Approved:</span> {fmtDate(investor.approvedAt)}</div>
+      </div>
+
+      <div className="invModal__statusSection">
+        <div className="invModal__label">Status Action</div>
+        <div className="invModal__statuses">
+          <button
+            type="button"
+            disabled={!isPending || submitting}
+            className={`invModal__statusBtn ${nextStatus === "REJECTED" ? "invModal__statusBtn--danger invModal__statusBtn--active" : "invModal__statusBtn--danger"}`}
+            onClick={() => setNextStatus("REJECTED")}
+          >
+            Reject
+          </button>
+          <button
+            type="button"
+            disabled={!isPending || submitting}
+            className={`invModal__statusBtn ${nextStatus === "APPROVED" ? "invModal__statusBtn--success invModal__statusBtn--active" : "invModal__statusBtn--success"}`}
+            onClick={() => setNextStatus("APPROVED")}
+          >
+            Approve
+          </button>
+        </div>
+
+        {requiresReason ? (
+          <label className="invModal__reasonWrap">
+            <span>Rejection Reason</span>
+            <textarea
+              value={rejectionReason}
+              disabled={(isPending && nextStatus !== "REJECTED") || isApproved || submitting}
+              onChange={(e) => setRejectionReason(e.target.value)}
+              rows={3}
+              maxLength={500}
+            />
+          </label>
+        ) : null}
+      </div>
+
+      {submitError ? <div className="invModal__error">{submitError}</div> : null}
+
+      <div className="invModal__actions">
+        <button type="button" className="invModal__btn" onClick={onClose} disabled={submitting}>
+          Cancel
+        </button>
+        <button
+          type="button"
+          className="invModal__btn invModal__btn--primary"
+          onClick={handleSave}
+          disabled={submitting || isReadOnly || (isPending && !nextStatus) || (requiresReason && !rejectionReason.trim())}
+        >
+          {submitting ? "Saving..." : "Save"}
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export default function AdminInvestorReviewModal({
   open,
   investor,
@@ -25,28 +112,6 @@ export default function AdminInvestorReviewModal({
 }) {
   const status = investor?.status ?? "";
   const isPending = status === "PENDING";
-  const isApproved = status === "APPROVED";
-  const isRejected = status === "REJECTED";
-
-  const [nextStatus, setNextStatus] = useState("APPROVED");
-  const [rejectionReason, setRejectionReason] = useState("");
-
-  useEffect(() => {
-    if (!open || !investor) return;
-    setNextStatus(isPending ? "APPROVED" : status);
-    setRejectionReason(investor.rejectionReason ?? "");
-  }, [open, investor, status, isPending]);
-
-  const isReadOnly = isApproved;
-  const requiresReason = useMemo(
-    () => (isPending && nextStatus === "REJECTED") || isRejected,
-    [isPending, nextStatus, isRejected],
-  );
-
-  function handleSave() {
-    if (isReadOnly) return;
-    onSave?.({ status: nextStatus, rejectionReason });
-  }
 
   return (
     <Modal
@@ -56,69 +121,14 @@ export default function AdminInvestorReviewModal({
       width={760}
     >
       {!investor ? null : (
-        <div className="invModal">
-          <div className="invModal__grid">
-            <div><span>Name:</span> {investor.firstName} {investor.lastName}</div>
-            <div><span>Company:</span> {investor.companyName || "—"}</div>
-            <div><span>Email:</span> {investor.email}</div>
-            <div><span>Phone:</span> {investor.phone || "—"}</div>
-            <div><span>Status:</span> {investor.status}</div>
-            <div><span>Created:</span> {fmtDate(investor.createdAt)}</div>
-            <div><span>Updated:</span> {fmtDate(investor.updatedAt)}</div>
-            <div><span>Approved:</span> {fmtDate(investor.approvedAt)}</div>
-          </div>
-
-          <div className="invModal__statusSection">
-            <div className="invModal__label">Status Action</div>
-            <div className="invModal__statuses">
-              <button
-                type="button"
-                disabled={!isPending || submitting}
-                className={`invModal__statusBtn ${nextStatus === "REJECTED" ? "invModal__statusBtn--danger invModal__statusBtn--active" : "invModal__statusBtn--danger"}`}
-                onClick={() => setNextStatus("REJECTED")}
-              >
-                Reject
-              </button>
-              <button
-                type="button"
-                disabled={!isPending || submitting}
-                className={`invModal__statusBtn ${nextStatus === "APPROVED" ? "invModal__statusBtn--success invModal__statusBtn--active" : "invModal__statusBtn--success"}`}
-                onClick={() => setNextStatus("APPROVED")}
-              >
-                Approve
-              </button>
-            </div>
-
-            {requiresReason ? (
-              <label className="invModal__reasonWrap">
-                <span>Rejection Reason</span>
-                <textarea
-                  value={rejectionReason}
-                  disabled={(isPending && nextStatus !== "REJECTED") || isApproved || submitting}
-                  onChange={(e) => setRejectionReason(e.target.value)}
-                  rows={3}
-                  maxLength={500}
-                />
-              </label>
-            ) : null}
-          </div>
-
-          {submitError ? <div className="invModal__error">{submitError}</div> : null}
-
-          <div className="invModal__actions">
-            <button type="button" className="invModal__btn" onClick={onClose} disabled={submitting}>
-              Cancel
-            </button>
-            <button
-              type="button"
-              className="invModal__btn invModal__btn--primary"
-              onClick={handleSave}
-              disabled={submitting || isReadOnly || (requiresReason && !rejectionReason.trim())}
-            >
-              {submitting ? "Saving..." : "Save"}
-            </button>
-          </div>
-        </div>
+        <ReviewBody
+          key={`${investor.id}-${open ? "open" : "closed"}`}
+          investor={investor}
+          submitting={submitting}
+          submitError={submitError}
+          onClose={onClose}
+          onSave={onSave}
+        />
       )}
     </Modal>
   );


### PR DESCRIPTION
### Motivation
- The shared Modal had a broken backdrop/close control and invisible title color, and the admin review modal preselected a status for pending investors which prevented explicit admin choice and inconsistent styling.
- Align review modal interactions and visuals with `PropertyUpsertModal` so admin workflows, hover/active behavior, and button styling are consistent.

### Description
- Fixed modal backdrop and close control in `frontend/src/components/Modal.css` by changing `backdrop-filter: blue(8px)` to `blur(8px)`, adding title color fallback and a hover style for `.mv-modal__x` so the “X” is visible and interactive.
- Refactored `AdminInvestorReviewModal` into a `ReviewBody` component and moved local state there in `frontend/src/modals/AdminInvestorReviewModal.jsx` so state resets cleanly when the modal opens, changed initial `nextStatus` to `""` for pending investors, and added guards so Save is disabled until an explicit status is chosen (and when required, a rejection reason is provided).
- Restyled the admin investor review modal in `frontend/src/modals/AdminInvestorReviewModal.css` by introducing CSS variables, matching button/prefix/focus patterns from `PropertyUpsertModal`, adding transition/hover/active behavior for approve/reject buttons (inverse-color hover), improving textarea focus, and aligning Save/Cancel button styles with the upsert modal.

### Testing
- Ran `npm run lint` from `frontend/` and the lint pass succeeded.
- Launched the dev site; an automated Playwright screenshot attempt failed due to a Chromium environment crash in the container (SIGSEGV), so visual verification via headless browser could not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d183cd5c8832c95e85a4014e0d6f6)