### PR TITLE
Add admin passcode password recovery

### DIFF
--- a/backend/src/main/java/com/megna/backend/application/service/AuthService.java
+++ b/backend/src/main/java/com/megna/backend/application/service/AuthService.java
@@ -19,6 +19,7 @@ import com.megna.backend.infrastructure.config.ContactProperties;
 import com.megna.backend.infrastructure.security.SecurityUtils;
 import com.megna.backend.infrastructure.security.jwt.JwtService;
 import com.megna.backend.interfaces.rest.dto.admin.AdminCredentialsUpdateRequestDto;
+import com.megna.backend.interfaces.rest.dto.auth.AdminPasswordResetRequestDto;
 import com.megna.backend.interfaces.rest.dto.auth.ChangePasswordRequestDto;
 import com.megna.backend.interfaces.rest.dto.auth.ForgotPasswordRequestDto;
 import com.megna.backend.interfaces.rest.dto.auth.LoginRequestDto;
@@ -60,6 +61,7 @@ public class AuthService {
     private static final String PRINCIPAL_INVESTOR = "INVESTOR";
     private static final String PRINCIPAL_SELLER = "SELLER";
     private static final String INVALID_RESET_TOKEN_MESSAGE = "Invalid or expired reset token";
+    private static final String INVALID_ADMIN_PASSCODE_MESSAGE = "Invalid or expired passcode";
     private static final String INVALID_REFRESH_TOKEN_MESSAGE = "Invalid or expired refresh token";
     private static final String RESET_PASSWORD_TEMPLATE_ALIAS = "reset-password-cid-v1";
     private static final String INVESTOR_SIGNUP_UNDER_REVIEW_TEMPLATE_ALIAS = "investor-signup-under-review-cid-v1";
@@ -68,6 +70,7 @@ public class AuthService {
     private static final DateTimeFormatter ADMIN_SIGNUP_DATE_TIME_FORMATTER =
             DateTimeFormatter.ofPattern("yyyy-MM-dd h:mm a 'CT'");
     private static final int OPAQUE_TOKEN_BYTE_LENGTH = 32;
+    private static final int ADMIN_PASSCODE_UPPER_BOUND = 1_000_000;
     private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
     private final InvestorRepository investorRepository;
@@ -283,22 +286,28 @@ public class AuthService {
                 principal.id()
         );
 
-        String rawToken = generateOpaqueToken();
+        boolean adminReset = PRINCIPAL_ADMIN.equals(principal.type());
+        String resetCredential = adminReset ? generateAdminPasscode() : generateOpaqueToken();
         PasswordResetToken resetToken = new PasswordResetToken();
         resetToken.setPrincipalType(principal.type());
         resetToken.setPrincipalId(principal.id());
-        resetToken.setTokenHash(hashToken(rawToken));
-        resetToken.setExpiresAt(LocalDateTime.now().plusMinutes(resolvePasswordResetTtlMinutes()));
+        resetToken.setTokenHash(adminReset
+                ? passwordEncoder.encode(resetCredential)
+                : hashToken(resetCredential));
+        resetToken.setExpiresAt(LocalDateTime.now().plusMinutes(adminReset
+                ? resolveAdminPasswordResetCodeTtlMinutes()
+                : resolvePasswordResetTtlMinutes()));
         passwordResetTokenRepository.save(resetToken);
 
         try {
-            boolean sent = transactionalEmailService.sendTransactional(
-                    TransactionalEmailRequest.template(
+            TransactionalEmailRequest emailRequest = adminReset
+                    ? buildAdminPasswordResetEmail(principal.email(), resetCredential)
+                    : TransactionalEmailRequest.template(
                             principal.email(),
                             RESET_PASSWORD_TEMPLATE_ALIAS,
-                            buildPasswordResetModel(rawToken, principal.greetingName())
-                    )
-            );
+                            buildPasswordResetModel(resetCredential, principal.greetingName())
+                    );
+            boolean sent = transactionalEmailService.sendTransactional(emailRequest);
             if (!sent) {
                 log.warn("Password reset email was not delivered for principalType={} principalId={}",
                         principal.type(), principal.id());
@@ -310,7 +319,57 @@ public class AuthService {
         }
     }
 
-    @Transactional
+    @Transactional(noRollbackFor = ResponseStatusException.class)
+    public void resetAdminPassword(AdminPasswordResetRequestDto dto) {
+        String email = normalizeEmail(dto.email());
+        String passcode = dto.passcode().trim();
+        String newPassword = dto.newPassword().trim();
+
+        Admin admin = adminRepository.findByEmail(email)
+                .orElseThrow(this::invalidAdminPasscode);
+        PasswordResetToken resetToken = passwordResetTokenRepository
+                .findTopByPrincipalTypeAndPrincipalIdAndUsedAtIsNullOrderByCreatedAtDescIdDesc(
+                        PRINCIPAL_ADMIN,
+                        admin.getId()
+                )
+                .orElseThrow(this::invalidAdminPasscode);
+
+        LocalDateTime now = LocalDateTime.now();
+        int maxAttempts = resolveAdminPasswordResetMaxAttempts();
+        if (resetToken.getExpiresAt() == null
+                || resetToken.getExpiresAt().isBefore(now)
+                || resetToken.getVerificationAttempts() >= maxAttempts) {
+            resetToken.setUsedAt(now);
+            passwordResetTokenRepository.save(resetToken);
+            throw invalidAdminPasscode();
+        }
+
+        if (!passwordEncoder.matches(passcode, resetToken.getTokenHash())) {
+            int failedAttempts = resetToken.getVerificationAttempts() + 1;
+            resetToken.setVerificationAttempts(failedAttempts);
+            if (failedAttempts >= maxAttempts) {
+                resetToken.setUsedAt(now);
+            }
+            passwordResetTokenRepository.save(resetToken);
+            throw invalidAdminPasscode();
+        }
+
+        ensurePasswordDifferent(newPassword, admin.getPasswordHash());
+        admin.setPasswordHash(passwordEncoder.encode(newPassword));
+        adminRepository.save(admin);
+
+        resetToken.setUsedAt(now);
+        passwordResetTokenRepository.save(resetToken);
+        passwordResetTokenRepository.markActiveTokensUsed(
+                PRINCIPAL_ADMIN,
+                admin.getId(),
+                now,
+                resetToken.getId()
+        );
+        revokeActiveRefreshTokens(PRINCIPAL_ADMIN, admin.getId(), now);
+    }
+
+    @Transactional(noRollbackFor = ResponseStatusException.class)
     public void resetPassword(ResetPasswordRequestDto dto) {
         String rawToken = dto.token().trim();
         String newPassword = dto.newPassword().trim();
@@ -587,6 +646,17 @@ public class AuthService {
     }
 
     private PrincipalRef resolvePasswordResetPrincipal(String email) {
+        var adminOpt = adminRepository.findByEmail(email);
+        if (adminOpt.isPresent()) {
+            Admin admin = adminOpt.get();
+            return new PrincipalRef(
+                    PRINCIPAL_ADMIN,
+                    admin.getId(),
+                    admin.getEmail(),
+                    "Megna admin"
+            );
+        }
+
         var investorOpt = investorRepository.findByEmail(email);
         if (investorOpt.isPresent()) {
             Investor investor = investorOpt.get();
@@ -617,6 +687,16 @@ public class AuthService {
         return ttlMinutes > 0 ? ttlMinutes : 30;
     }
 
+    private long resolveAdminPasswordResetCodeTtlMinutes() {
+        long ttlMinutes = authProperties.getAdminPasswordResetCodeTtlMinutes();
+        return ttlMinutes > 0 ? ttlMinutes : 10;
+    }
+
+    private int resolveAdminPasswordResetMaxAttempts() {
+        int maxAttempts = authProperties.getAdminPasswordResetMaxAttempts();
+        return maxAttempts > 0 ? maxAttempts : 5;
+    }
+
     private long resolveRefreshTokenTtlMinutes() {
         long ttlMinutes = authProperties.getRefreshTokenTtlMinutes();
         return ttlMinutes > 0 ? ttlMinutes : 20160;
@@ -637,6 +717,28 @@ public class AuthService {
         model.put("action_url", resetLink);
         model.put("footer_text", "If you didn't request this, you can ignore this email.");
         return model;
+    }
+
+    private TransactionalEmailRequest buildAdminPasswordResetEmail(String email, String passcode) {
+        long ttlMinutes = resolveAdminPasswordResetCodeTtlMinutes();
+        String resetLink = buildAdminPasscodeResetLink(email);
+        String textBody = """
+                We received a request to reset the Megna admin password.
+
+                Your one-time passcode is: %s
+
+                This passcode expires in %d minutes and can only be used once.
+                Enter it on the password reset page:
+                %s
+
+                If you did not request this reset, you can ignore this email.
+                """.formatted(passcode, ttlMinutes, resetLink);
+
+        return new TransactionalEmailRequest(
+                email,
+                "Your Megna admin password reset code",
+                textBody
+        );
     }
 
     private void sendInvestorSignupUnderReviewEmail(Investor investor) {
@@ -773,6 +875,22 @@ public class AuthService {
         return baseUrl + separator + "token=" + urlEncode(rawToken);
     }
 
+    private String buildAdminPasscodeResetLink(String email) {
+        String baseUrl = authProperties.getPasswordResetUrlBase() == null
+                ? ""
+                : authProperties.getPasswordResetUrlBase().trim();
+        if (baseUrl.isBlank()) {
+            return "";
+        }
+
+        String separator = baseUrl.contains("?") ? "&" : "?";
+        return baseUrl + separator + "email=" + urlEncode(email);
+    }
+
+    private String generateAdminPasscode() {
+        return "%06d".formatted(SECURE_RANDOM.nextInt(ADMIN_PASSCODE_UPPER_BOUND));
+    }
+
     private String generateOpaqueToken() {
         byte[] bytes = new byte[OPAQUE_TOKEN_BYTE_LENGTH];
         SECURE_RANDOM.nextBytes(bytes);
@@ -807,6 +925,10 @@ public class AuthService {
 
     private ResponseStatusException invalidResetToken() {
         return new ResponseStatusException(HttpStatus.BAD_REQUEST, INVALID_RESET_TOKEN_MESSAGE);
+    }
+
+    private ResponseStatusException invalidAdminPasscode() {
+        return new ResponseStatusException(HttpStatus.BAD_REQUEST, INVALID_ADMIN_PASSCODE_MESSAGE);
     }
 
     private ResponseStatusException invalidRefreshToken() {

--- a/backend/src/main/java/com/megna/backend/domain/entity/PasswordResetToken.java
+++ b/backend/src/main/java/com/megna/backend/domain/entity/PasswordResetToken.java
@@ -39,6 +39,9 @@ public class PasswordResetToken {
     @Column(name = "used_at")
     private LocalDateTime usedAt;
 
+    @Column(name = "verification_attempts", nullable = false, columnDefinition = "INT DEFAULT 0")
+    private int verificationAttempts;
+
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
 

--- a/backend/src/main/java/com/megna/backend/domain/repository/PasswordResetTokenRepository.java
+++ b/backend/src/main/java/com/megna/backend/domain/repository/PasswordResetTokenRepository.java
@@ -1,7 +1,9 @@
 package com.megna.backend.domain.repository;
 
 import com.megna.backend.domain.entity.PasswordResetToken;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,7 +13,14 @@ import java.util.Optional;
 
 public interface PasswordResetTokenRepository extends JpaRepository<PasswordResetToken, Long> {
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<PasswordResetToken> findByTokenHashAndUsedAtIsNull(String tokenHash);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<PasswordResetToken> findTopByPrincipalTypeAndPrincipalIdAndUsedAtIsNullOrderByCreatedAtDescIdDesc(
+            String principalType,
+            Long principalId
+    );
 
     void deleteByPrincipalTypeAndPrincipalIdAndUsedAtIsNull(String principalType, Long principalId);
 

--- a/backend/src/main/java/com/megna/backend/infrastructure/config/AbuseProtectionWebConfig.java
+++ b/backend/src/main/java/com/megna/backend/infrastructure/config/AbuseProtectionWebConfig.java
@@ -22,6 +22,7 @@ public class AbuseProtectionWebConfig implements WebMvcConfigurer {
                         "/api/auth/invitations/*/accept",
                         "/api/auth/password/forgot",
                         "/api/auth/password/reset",
+                        "/api/auth/password/reset/admin",
                         "/api/auth/password/change",
                         "/api/admin/account/credentials",
                         "/api/auth/refresh",

--- a/backend/src/main/java/com/megna/backend/infrastructure/config/AuthProperties.java
+++ b/backend/src/main/java/com/megna/backend/infrastructure/config/AuthProperties.java
@@ -12,6 +12,8 @@ import org.springframework.stereotype.Component;
 public class AuthProperties {
     private String passwordResetUrlBase = "http://localhost:5173/reset-password";
     private long passwordResetTokenTtlMinutes = 30;
+    private long adminPasswordResetCodeTtlMinutes = 10;
+    private int adminPasswordResetMaxAttempts = 5;
     private String invitationUrlBase = "http://localhost:5173/invite/accept";
     private long invitationTtlDays = 7;
 

--- a/backend/src/main/java/com/megna/backend/infrastructure/security/PublicEndpointRateLimitInterceptor.java
+++ b/backend/src/main/java/com/megna/backend/infrastructure/security/PublicEndpointRateLimitInterceptor.java
@@ -124,6 +124,8 @@ public class PublicEndpointRateLimitInterceptor implements HandlerInterceptor {
                     new RateLimitRule("auth.password-forgot", abuseProtectionProperties.getAuthPasswordForgot(), Scope.IP);
             case "/api/auth/password/reset" ->
                     new RateLimitRule("auth.password-reset", abuseProtectionProperties.getAuthPasswordReset(), Scope.IP);
+            case "/api/auth/password/reset/admin" ->
+                    new RateLimitRule("auth.password-reset", abuseProtectionProperties.getAuthPasswordReset(), Scope.IP);
             case "/api/auth/password/change" ->
                     new RateLimitRule("auth.password-change", abuseProtectionProperties.getAuthPasswordChange(), Scope.USER_OR_IP);
             case "/api/auth/refresh" ->

--- a/backend/src/main/java/com/megna/backend/infrastructure/security/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/com/megna/backend/infrastructure/security/jwt/JwtAuthenticationFilter.java
@@ -124,6 +124,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 || path.startsWith("/api/auth/invitations/")
                 || path.equals("/api/auth/password/forgot")
                 || path.equals("/api/auth/password/reset")
+                || path.equals("/api/auth/password/reset/admin")
                 || path.equals("/api/auth/refresh")
                 || path.equals("/api/auth/logout");
     }

--- a/backend/src/main/java/com/megna/backend/interfaces/rest/controller/AuthController.java
+++ b/backend/src/main/java/com/megna/backend/interfaces/rest/controller/AuthController.java
@@ -7,6 +7,7 @@ import com.megna.backend.domain.repository.InvestorRepository;
 import com.megna.backend.domain.repository.SellerRepository;
 import com.megna.backend.infrastructure.security.RefreshTokenCookieService;
 import com.megna.backend.infrastructure.security.SecurityUtils;
+import com.megna.backend.interfaces.rest.dto.auth.AdminPasswordResetRequestDto;
 import com.megna.backend.interfaces.rest.dto.auth.ChangePasswordRequestDto;
 import com.megna.backend.interfaces.rest.dto.auth.ForgotPasswordRequestDto;
 import com.megna.backend.interfaces.rest.dto.auth.LoginRequestDto;
@@ -153,6 +154,12 @@ public class AuthController {
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void resetPassword(@Valid @RequestBody ResetPasswordRequestDto dto) {
         authService.resetPassword(dto);
+    }
+
+    @PostMapping("/password/reset/admin")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    public void resetAdminPassword(@Valid @RequestBody AdminPasswordResetRequestDto dto) {
+        authService.resetAdminPassword(dto);
     }
 
     @PostMapping("/register")

--- a/backend/src/main/java/com/megna/backend/interfaces/rest/dto/auth/AdminPasswordResetRequestDto.java
+++ b/backend/src/main/java/com/megna/backend/interfaces/rest/dto/auth/AdminPasswordResetRequestDto.java
@@ -1,0 +1,13 @@
+package com.megna.backend.interfaces.rest.dto.auth;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record AdminPasswordResetRequestDto(
+        @NotBlank @Email @Size(max = 255) String email,
+        @NotBlank @Pattern(regexp = "[0-9]{6}", message = "Passcode must be 6 digits") String passcode,
+        @NotBlank @Size(min = 8, max = 255) String newPassword
+) {
+}

--- a/backend/src/main/resources/application.yaml
+++ b/backend/src/main/resources/application.yaml
@@ -35,6 +35,8 @@ app:
   auth:
     password-reset-url-base: ${APP_AUTH_PASSWORD_RESET_URL_BASE:http://localhost:5173/reset-password}
     password-reset-token-ttl-minutes: ${APP_AUTH_PASSWORD_RESET_TOKEN_TTL_MINUTES:30}
+    admin-password-reset-code-ttl-minutes: ${APP_AUTH_ADMIN_PASSWORD_RESET_CODE_TTL_MINUTES:10}
+    admin-password-reset-max-attempts: ${APP_AUTH_ADMIN_PASSWORD_RESET_MAX_ATTEMPTS:5}
     invitation-url-base: ${APP_AUTH_INVITATION_URL_BASE:http://localhost:5173/invite/accept}
     invitation-ttl-days: ${APP_AUTH_INVITATION_TTL_DAYS:7}
     refresh-token-ttl-minutes: ${APP_AUTH_REFRESH_TOKEN_TTL_MINUTES:20160}

--- a/backend/src/main/resources/db/migration/V35__add_password_reset_verification_attempts.sql
+++ b/backend/src/main/resources/db/migration/V35__add_password_reset_verification_attempts.sql
@@ -1,0 +1,2 @@
+ALTER TABLE password_reset_tokens
+    ADD COLUMN verification_attempts INT NOT NULL DEFAULT 0 AFTER used_at;

--- a/backend/src/test/java/com/megna/backend/AuthPasswordResetIntegrationTest.java
+++ b/backend/src/test/java/com/megna/backend/AuthPasswordResetIntegrationTest.java
@@ -108,16 +108,127 @@ class AuthPasswordResetIntegrationTest {
     }
 
     @Test
-    void forgotPasswordShouldIgnoreAdminEmail() throws Exception {
-        insertAdmin("admin.reset@example.com", "AdminPass123!");
+    void forgotPasswordShouldCreatePasscodeForAdminEmail() throws Exception {
+        Long adminId = insertAdmin("admin.reset@example.com", "AdminPass123!");
 
         mockMvc.perform(post("/api/auth/password/forgot")
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(new ForgotBody("admin.reset@example.com"))))
                 .andExpect(status().isNoContent());
 
-        Integer tokenCount = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM password_reset_tokens", Integer.class);
-        org.junit.jupiter.api.Assertions.assertEquals(0, tokenCount);
+        Integer tokenCount = jdbcTemplate.queryForObject(
+                """
+                        SELECT COUNT(*)
+                        FROM password_reset_tokens
+                        WHERE principal_type = 'ADMIN'
+                          AND principal_id = ?
+                          AND used_at IS NULL
+                          AND verification_attempts = 0
+                        """,
+                Integer.class,
+                adminId
+        );
+        org.junit.jupiter.api.Assertions.assertEquals(1, tokenCount);
+    }
+
+    @Test
+    void adminPasscodeShouldResetPasswordRevokeSessionsAndRejectReuse() throws Exception {
+        String email = "admin.flow@example.com";
+        String currentPassword = "AdminPass123!";
+        String newPassword = "AdminPass456!";
+        String passcode = "314159";
+        Long adminId = insertAdmin(email, currentPassword);
+        insertAdminPasscode(adminId, passcode, LocalDateTime.now().plusMinutes(10));
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new LoginBody(email, currentPassword))))
+                .andExpect(status().isOk());
+
+        mockMvc.perform(post("/api/auth/password/reset/admin")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new AdminResetBody(email, passcode, newPassword)
+                        )))
+                .andExpect(status().isNoContent());
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new LoginBody(email, currentPassword))))
+                .andExpect(status().isUnauthorized());
+
+        mockMvc.perform(post("/api/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new LoginBody(email, newPassword))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.user.role").value("ADMIN"));
+
+        Integer activeOldSessions = jdbcTemplate.queryForObject(
+                """
+                        SELECT COUNT(*)
+                        FROM refresh_tokens
+                        WHERE principal_type = 'ADMIN'
+                          AND principal_id = ?
+                          AND revoked_at IS NULL
+                        """,
+                Integer.class,
+                adminId
+        );
+        org.junit.jupiter.api.Assertions.assertEquals(1, activeOldSessions);
+
+        mockMvc.perform(post("/api/auth/password/reset/admin")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new AdminResetBody(email, passcode, "AdminPass789!")
+                        )))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Invalid or expired passcode"));
+    }
+
+    @Test
+    void wrongAdminPasscodesShouldIncrementAttemptsAndLockTheCode() throws Exception {
+        String email = "admin.attempts@example.com";
+        Long adminId = insertAdmin(email, "AdminPass123!");
+        insertAdminPasscode(adminId, "654321", LocalDateTime.now().plusMinutes(10));
+
+        for (int attempt = 1; attempt <= 5; attempt++) {
+            mockMvc.perform(post("/api/auth/password/reset/admin")
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(
+                                    new AdminResetBody(email, "000000", "AdminPass456!")
+                            )))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.message").value("Invalid or expired passcode"));
+        }
+
+        Integer attempts = jdbcTemplate.queryForObject(
+                """
+                        SELECT verification_attempts
+                        FROM password_reset_tokens
+                        WHERE principal_type = 'ADMIN' AND principal_id = ?
+                        """,
+                Integer.class,
+                adminId
+        );
+        Timestamp usedAt = jdbcTemplate.queryForObject(
+                """
+                        SELECT used_at
+                        FROM password_reset_tokens
+                        WHERE principal_type = 'ADMIN' AND principal_id = ?
+                        """,
+                Timestamp.class,
+                adminId
+        );
+        org.junit.jupiter.api.Assertions.assertEquals(5, attempts);
+        org.junit.jupiter.api.Assertions.assertNotNull(usedAt);
+
+        mockMvc.perform(post("/api/auth/password/reset/admin")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(
+                                new AdminResetBody(email, "654321", "AdminPass456!")
+                        )))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("Invalid or expired passcode"));
     }
 
     @Test
@@ -167,6 +278,17 @@ class AuthPasswordResetIntegrationTest {
                         .content(objectMapper.writeValueAsString(new ResetBody(rawToken, "InvestorPass456!"))))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("Invalid or expired reset token"));
+
+        Timestamp usedAt = jdbcTemplate.queryForObject(
+                """
+                        SELECT used_at
+                        FROM password_reset_tokens
+                        WHERE principal_type = 'INVESTOR' AND principal_id = ?
+                        """,
+                Timestamp.class,
+                investorId
+        );
+        org.junit.jupiter.api.Assertions.assertNotNull(usedAt);
 
         mockMvc.perform(post("/api/auth/login")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -245,7 +367,7 @@ class AuthPasswordResetIntegrationTest {
         return jdbcTemplate.queryForObject("SELECT id FROM sellers WHERE email = ?", Long.class, email);
     }
 
-    private void insertAdmin(String email, String password) {
+    private Long insertAdmin(String email, String password) {
         LocalDateTime now = LocalDateTime.now();
         jdbcTemplate.update("""
                         INSERT INTO admins
@@ -257,6 +379,25 @@ class AuthPasswordResetIntegrationTest {
                 Timestamp.valueOf(now),
                 Timestamp.valueOf(now)
         );
+
+        return jdbcTemplate.queryForObject("SELECT id FROM admins WHERE email = ?", Long.class, email);
+    }
+
+    private void insertAdminPasscode(Long adminId, String passcode, LocalDateTime expiresAt) {
+        jdbcTemplate.update("""
+                        INSERT INTO password_reset_tokens
+                        (principal_type, principal_id, token_hash, expires_at, used_at,
+                         verification_attempts, created_at)
+                        VALUES (?, ?, ?, ?, ?, ?, ?)
+                        """,
+                "ADMIN",
+                adminId,
+                passwordEncoder.encode(passcode),
+                Timestamp.valueOf(expiresAt),
+                null,
+                0,
+                Timestamp.valueOf(LocalDateTime.now())
+        );
     }
 
     private void insertPasswordResetToken(
@@ -266,16 +407,18 @@ class AuthPasswordResetIntegrationTest {
             LocalDateTime expiresAt,
             LocalDateTime usedAt
     ) {
-        jdbcTemplate.update("""
+                jdbcTemplate.update("""
                         INSERT INTO password_reset_tokens
-                        (principal_type, principal_id, token_hash, expires_at, used_at, created_at)
-                        VALUES (?, ?, ?, ?, ?, ?)
+                        (principal_type, principal_id, token_hash, expires_at, used_at,
+                         verification_attempts, created_at)
+                        VALUES (?, ?, ?, ?, ?, ?, ?)
                         """,
                 principalType,
                 principalId,
                 hashToken(rawToken),
                 Timestamp.valueOf(expiresAt),
                 usedAt == null ? null : Timestamp.valueOf(usedAt),
+                0,
                 Timestamp.valueOf(LocalDateTime.now())
         );
     }
@@ -292,5 +435,6 @@ class AuthPasswordResetIntegrationTest {
 
     private record ForgotBody(String email) {}
     private record ResetBody(String token, String newPassword) {}
+    private record AdminResetBody(String email, String passcode, String newPassword) {}
     private record LoginBody(String email, String password) {}
 }

--- a/backend/src/test/java/com/megna/backend/application/service/AuthServicePasswordResetTest.java
+++ b/backend/src/test/java/com/megna/backend/application/service/AuthServicePasswordResetTest.java
@@ -2,6 +2,7 @@ package com.megna.backend.application.service;
 
 import com.megna.backend.application.service.email.TransactionalEmailRequest;
 import com.megna.backend.application.service.email.TransactionalEmailService;
+import com.megna.backend.domain.entity.Admin;
 import com.megna.backend.domain.entity.Investor;
 import com.megna.backend.domain.entity.PasswordResetToken;
 import com.megna.backend.domain.repository.AdminRepository;
@@ -38,7 +39,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
@@ -153,18 +153,44 @@ class AuthServicePasswordResetTest {
     }
 
     @Test
-    void requestPasswordResetShouldIgnoreAdminAccounts() {
+    void requestPasswordResetShouldStoreHashedPasscodeAndEmailAdmin() {
         AuthService authService = newAuthService();
         String email = "admin@example.com";
+        Admin admin = new Admin();
+        admin.setId(7L);
+        admin.setEmail(email);
 
-        when(investorRepository.findByEmail(email)).thenReturn(Optional.empty());
-        when(sellerRepository.findByEmail(email)).thenReturn(Optional.empty());
+        when(adminRepository.findByEmail(email)).thenReturn(Optional.of(admin));
+        when(authProperties.getAdminPasswordResetCodeTtlMinutes()).thenReturn(10L);
+        when(authProperties.getPasswordResetUrlBase()).thenReturn("https://megna.us/reset-password");
+        when(passwordEncoder.encode(any(String.class))).thenAnswer(invocation ->
+                "encoded:" + invocation.getArgument(0, String.class));
+        when(passwordResetTokenRepository.save(any(PasswordResetToken.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(transactionalEmailService.sendTransactional(any(TransactionalEmailRequest.class))).thenReturn(true);
 
         authService.requestPasswordReset(new ForgotPasswordRequestDto(email));
 
-        verify(passwordResetTokenRepository, never()).save(any());
-        verify(transactionalEmailService, never()).sendTransactional(any());
-        verifyNoInteractions(adminRepository);
+        ArgumentCaptor<PasswordResetToken> tokenCaptor = ArgumentCaptor.forClass(PasswordResetToken.class);
+        verify(passwordResetTokenRepository).save(tokenCaptor.capture());
+        PasswordResetToken savedToken = tokenCaptor.getValue();
+        assertEquals("ADMIN", savedToken.getPrincipalType());
+        assertEquals(7L, savedToken.getPrincipalId());
+        assertTrue(savedToken.getExpiresAt().isAfter(LocalDateTime.now().plusMinutes(9)));
+
+        ArgumentCaptor<TransactionalEmailRequest> emailCaptor =
+                ArgumentCaptor.forClass(TransactionalEmailRequest.class);
+        verify(transactionalEmailService).sendTransactional(emailCaptor.capture());
+        TransactionalEmailRequest request = emailCaptor.getValue();
+        Matcher passcodeMatcher = Pattern.compile("one-time passcode is: (\\d{6})")
+                .matcher(request.textBody());
+        assertTrue(passcodeMatcher.find());
+        String passcode = passcodeMatcher.group(1);
+        assertEquals("encoded:" + passcode, savedToken.getTokenHash());
+        assertEquals("Your Megna admin password reset code", request.subject());
+        assertTrue(request.textBody().contains(
+                "https://megna.us/reset-password?email=admin%40example.com"
+        ));
     }
 
     private AuthService newAuthService() {

--- a/backend/src/test/java/com/megna/backend/infrastructure/security/PublicEndpointRateLimitInterceptorTest.java
+++ b/backend/src/test/java/com/megna/backend/infrastructure/security/PublicEndpointRateLimitInterceptorTest.java
@@ -82,4 +82,18 @@ class PublicEndpointRateLimitInterceptorTest {
         verify(limiter).evaluate(eq("inquiries.create"), keyCaptor.capture(), any(), eq(properties));
         assertEquals("ip:198.51.100.51", keyCaptor.getValue());
     }
+
+    @Test
+    void rateLimitsAdminPasscodeResetByIp() throws Exception {
+        when(request.getMethod()).thenReturn("POST");
+        when(request.getRequestURI()).thenReturn("/api/auth/password/reset/admin");
+        when(request.getContextPath()).thenReturn("");
+        when(request.getHeader("X-Forwarded-For")).thenReturn("203.0.113.25");
+
+        interceptor.preHandle(request, response, new Object());
+
+        ArgumentCaptor<String> keyCaptor = ArgumentCaptor.forClass(String.class);
+        verify(limiter).evaluate(eq("auth.password-reset"), keyCaptor.capture(), any(), eq(properties));
+        assertEquals("ip:203.0.113.25", keyCaptor.getValue());
+    }
 }

--- a/frontend/src/api/modules/authApi.js
+++ b/frontend/src/api/modules/authApi.js
@@ -72,12 +72,17 @@ export async function updateAdminCredentials(payload) {
 }
 
 export async function requestPasswordReset(payload) {
-    await apiClient.post(`${AUTH_BASE}/password/forgot`, payload);
+    await apiClient.post(`${AUTH_BASE}/password/forgot`, payload, AUTH_REQUEST_CONFIG);
     return true;
 }
 
 export async function resetPassword(payload) {
-    await apiClient.post(`${AUTH_BASE}/password/reset`, payload);
+    await apiClient.post(`${AUTH_BASE}/password/reset`, payload, AUTH_REQUEST_CONFIG);
+    return true;
+}
+
+export async function resetAdminPassword(payload) {
+    await apiClient.post(`${AUTH_BASE}/password/reset/admin`, payload, AUTH_REQUEST_CONFIG);
     return true;
 }
 

--- a/frontend/src/features/auth/modals/ForgotPasswordModal.jsx
+++ b/frontend/src/features/auth/modals/ForgotPasswordModal.jsx
@@ -50,6 +50,21 @@ export default function ForgotPasswordModal() {
     navigate("/login", { replace: true, state: loginLinkState });
   }
 
+  function enterAdminPasscode() {
+    const resetUrl = `/reset-password?email=${encodeURIComponent(email.trim())}`;
+    navigate(resetUrl, {
+      replace: true,
+      state: hasBackground
+        ? {
+            modal: true,
+            backgroundLocation: bg,
+            from: location.state?.from || "/app",
+            forceHomeOnClose,
+          }
+        : undefined,
+    });
+  }
+
   return (
     <div className={`forgotOverlay ${isClosing ? "forgotOverlay--closing" : ""}`} onMouseDown={close}>
       <div
@@ -77,6 +92,7 @@ export default function ForgotPasswordModal() {
             <>
               <div className="field">
                 <input
+                  id="forgot-password-email"
                   className="field__input"
                   value={email}
                   onChange={(event) => setEmail(event.target.value)}
@@ -84,11 +100,11 @@ export default function ForgotPasswordModal() {
                   autoComplete="email"
                   type="email"
                 />
-                <label className="field__label">Email</label>
+                <label className="field__label" htmlFor="forgot-password-email">Email</label>
               </div>
 
               <p className="forgotModal__hint">
-                Enter your account email. If it exists, we'll send a reset link.
+                Enter your account email. We'll send secure recovery instructions if it exists.
               </p>
 
               {error ? <div className="forgotModal__error">{error}</div> : null}
@@ -99,18 +115,22 @@ export default function ForgotPasswordModal() {
                 </button>
 
                 <button className="forgotModal__btn" disabled={loading || !email.trim()}>
-                  {loading ? "Sending..." : "Send reset link"}
+                  {loading ? "Sending..." : "Send instructions"}
                 </button>
               </div>
             </>
           ) : (
             <div className="forgotModal__success">
               <p className="forgotModal__successText">
-                If an account exists for {email.trim()}, we sent a reset link.
+                If an account exists for {email.trim()}, we sent recovery instructions.
+                Admins receive a six-digit passcode; other users receive a reset link.
               </p>
               <div className="forgotModal__actions forgotModal__actions--bottom">
-                <button type="button" className="forgotModal__btn forgotModal__btn--full" onClick={goToLogin}>
+                <button type="button" className="forgotModal__backBtn" onClick={goToLogin}>
                   Back to sign in
+                </button>
+                <button type="button" className="forgotModal__btn" onClick={enterAdminPasscode}>
+                  Enter admin passcode
                 </button>
               </div>
             </div>

--- a/frontend/src/features/auth/modals/ResetPasswordModal.css
+++ b/frontend/src/features/auth/modals/ResetPasswordModal.css
@@ -92,6 +92,12 @@
   border-color: var(--text);
 }
 
+.resetModal__passcode {
+  font-size: 22px;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: 0.32em;
+}
+
 .resetModal .field__label {
   position: absolute;
   left: 12px;

--- a/frontend/src/features/auth/modals/ResetPasswordModal.jsx
+++ b/frontend/src/features/auth/modals/ResetPasswordModal.jsx
@@ -1,6 +1,6 @@
 import { useLocation, useNavigate, useSearchParams } from "react-router-dom";
 import { useMemo, useState } from "react";
-import { resetPassword } from "@/api";
+import { resetAdminPassword, resetPassword } from "@/api";
 import "@/features/auth/modals/ResetPasswordModal.css";
 import { getPasswordStrength } from "@/shared/utils/passwordStrength";
 import { useAuthModalClose } from "@/features/auth/modals/useAuthModalClose";
@@ -17,10 +17,13 @@ export default function ResetPasswordModal() {
   const [confirmPassword, setConfirmPassword] = useState("");
   const [showPassword, setShowPassword] = useState(false);
   const [showConfirmPassword, setShowConfirmPassword] = useState(false);
+  const [passcode, setPasscode] = useState("");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [success, setSuccess] = useState(false);
   const token = (searchParams.get("token") || "").trim();
+  const email = (searchParams.get("email") || "").trim();
+  const isAdminPasscodeReset = !token && !!email;
   const passwordStrength = useMemo(() => getPasswordStrength(newPassword), [newPassword]);
   const { isClosing, close } = useAuthModalClose({
     navigate,
@@ -46,8 +49,13 @@ export default function ResetPasswordModal() {
     event.preventDefault();
     setError("");
 
-    if (!token) {
-      setError("Reset link is invalid or expired.");
+    if (!token && !isAdminPasscodeReset) {
+      setError("Reset request is invalid or expired.");
+      return;
+    }
+
+    if (isAdminPasscodeReset && !/^[0-9]{6}$/.test(passcode)) {
+      setError("Enter the six-digit passcode from the email.");
       return;
     }
 
@@ -63,8 +71,13 @@ export default function ResetPasswordModal() {
 
     setLoading(true);
     try {
-      await resetPassword({ token, newPassword });
+      if (isAdminPasscodeReset) {
+        await resetAdminPassword({ email, passcode, newPassword });
+      } else {
+        await resetPassword({ token, newPassword });
+      }
       setSuccess(true);
+      setPasscode("");
       setNewPassword("");
       setConfirmPassword("");
     } catch (requestError) {
@@ -81,7 +94,9 @@ export default function ResetPasswordModal() {
         onMouseDown={(event) => event.stopPropagation()}
       >
         <div className="resetModal__header">
-          <h2 className="resetModal__title">Set new password</h2>
+          <h2 className="resetModal__title">
+            {isAdminPasscodeReset ? "Enter admin passcode" : "Set new password"}
+          </h2>
           <div
             className="resetModal__close"
             onClick={close}
@@ -98,8 +113,35 @@ export default function ResetPasswordModal() {
 
         {!success ? (
           <form className="resetModal__form" onSubmit={handleSubmit}>
+            {isAdminPasscodeReset ? (
+              <>
+                <div className="field">
+                  <input
+                    id="admin-reset-passcode"
+                    className="field__input resetModal__passcode"
+                    value={passcode}
+                    onChange={(event) => setPasscode(
+                      event.target.value.replace(/[^0-9]/g, "").slice(0, 6)
+                    )}
+                    placeholder=" "
+                    autoComplete="one-time-code"
+                    inputMode="numeric"
+                    maxLength={6}
+                    autoFocus
+                  />
+                  <label className="field__label" htmlFor="admin-reset-passcode">
+                    Six-digit passcode
+                  </label>
+                </div>
+                <p className="resetModal__copy">
+                  Enter the passcode sent to {email}. Use it before it expires.
+                </p>
+              </>
+            ) : null}
+
             <div className="field field--password">
               <input
+                id="reset-new-password"
                 className="field__input"
                 value={newPassword}
                 onChange={(event) => setNewPassword(event.target.value)}
@@ -107,7 +149,7 @@ export default function ResetPasswordModal() {
                 autoComplete="new-password"
                 type={showPassword ? "text" : "password"}
               />
-              <label className="field__label">New password</label>
+              <label className="field__label" htmlFor="reset-new-password">New password</label>
               <button
                 type="button"
                 className="field__toggle"
@@ -131,6 +173,7 @@ export default function ResetPasswordModal() {
 
             <div className="field field--password">
               <input
+                id="reset-confirm-password"
                 className="field__input"
                 value={confirmPassword}
                 onChange={(event) => setConfirmPassword(event.target.value)}
@@ -138,7 +181,9 @@ export default function ResetPasswordModal() {
                 autoComplete="new-password"
                 type={showConfirmPassword ? "text" : "password"}
               />
-              <label className="field__label">Confirm password</label>
+              <label className="field__label" htmlFor="reset-confirm-password">
+                Confirm password
+              </label>
               <button
                 type="button"
                 className="field__toggle"
@@ -159,7 +204,13 @@ export default function ResetPasswordModal() {
             <div className="resetModal__actions resetModal__actions--bottom">
               <button
                 className="resetModal__btn resetModal__btn--full"
-                disabled={loading || !newPassword || !confirmPassword || !token}
+                disabled={
+                  loading
+                  || !newPassword
+                  || !confirmPassword
+                  || (!token && !isAdminPasscodeReset)
+                  || (isAdminPasscodeReset && passcode.length !== 6)
+                }
               >
                 {loading ? "Updating..." : "Update password"}
               </button>


### PR DESCRIPTION
## What changed

- Add six-digit one-time passcodes for admin password recovery
- Add the passcode entry UI while preserving investor and seller reset links
- Add expiry, attempt limits, hashed storage, rate limiting, one-time-use locking, and session revocation
- Persist expired-token invalidation and associate form labels for accessibility

## Why

Admins previously had no self-service recovery path when they forgot their password.

## Validation

- `./mvnw verify` — 152 tests passed
- `npm run lint`
- `npm run build`
- MySQL Flyway V35 migration validated against local MySQL
- Desktop and 320 px / 375 px mobile browser checks